### PR TITLE
fix/feat: handle blender versions < v3.3.0

### DIFF
--- a/setup_wizard/README.md
+++ b/setup_wizard/README.md
@@ -6,6 +6,9 @@ The goal of this tool is to streamline the character setup process. Whether it's
 
 **Important**: This tool is intended to be used with Festivity's shaders, found here: https://github.com/festivize/Blender-miHoYo-Shaders
 
+**Compatibility**: This tool has been tested on Blender Version 3.3.0 and attempts to support older versions of Blender, but working functionality is not guaranteed.
+
+
 ## Table of Contents
 1. [Tutorials/Screenshots](#tutorialsscreenshots)
 2. [Quick Start Guide](#quick-start-guide)
@@ -62,6 +65,8 @@ Download Tutorials:
 
 ## How to Disable Components on the UI
 This tool is broken up into many different components. The `config_ui.json` file can be used to enable or disable specific steps when running the `Run Entire Setup` or `Basic Setup`.
+
+Note: Outlines Setup is automatically disabled when running Blender Versions < v3.3.0
 
 Example of Disabling Outlines from `Run Entire Setup`:
 ```

--- a/setup_wizard/config_ui.json
+++ b/setup_wizard/config_ui.json
@@ -16,6 +16,18 @@
             "set_color_management_to_standard",
             "delete_specific_objects"
         ],
+        "GENSHIN_OT_setup_wizard_ui_no_outlines": [
+            "IMPORTANT_PLACEHOLDER_VALUE_KEEP_INDEX_ABOVE_0_setup_wizard_ui",
+            "import_character_model", 
+            "delete_empties",
+            "import_materials",
+            "replace_default_materials",
+            "import_character_textures",
+            "fix_transformations",
+            "setup_head_driver",
+            "set_color_management_to_standard",
+            "delete_specific_objects"
+        ],
         "GENSHIN_OT_set_up_character": [
             "IMPORTANT_PLACEHOLDER_VALUE_KEEP_INDEX_ABOVE_0_set_up_character",
             "import_character_model", 

--- a/setup_wizard/genshin_setup_wizard.py
+++ b/setup_wizard/genshin_setup_wizard.py
@@ -6,12 +6,24 @@ from bpy.types import Operator
 from setup_wizard.import_order import NextStepInvoker
 
 from setup_wizard.models import BasicSetupUIOperator
+from setup_wizard.ui_setup_wizard_menu import version_number_above_or_equal
 
 
 class GI_OT_GenshinSetupWizardUI(Operator, BasicSetupUIOperator):
     '''Runs through entire setup process'''
     bl_idname = 'genshin.setup_wizard_ui'
     bl_label = 'Genshin: Setup Wizard (UI)'
+
+    def execute(self, context):
+        next_step_index = 0
+
+        NextStepInvoker().invoke(
+            next_step_index,
+            'invoke_next_step_ui', 
+            high_level_step_name=self.bl_idname if version_number_above_or_equal((3, 3, 0)) \
+                else self.bl_idname + '_no_outlines'
+        )
+        return {'FINISHED'}
 
 
 class GI_OT_GenshinSetupWizard(Operator):

--- a/setup_wizard/ui_setup_wizard_menu.py
+++ b/setup_wizard/ui_setup_wizard_menu.py
@@ -63,12 +63,15 @@ class GI_PT_Basic_Setup_Wizard_UI_Layout(Panel):
             'Set Up Materials',
             icon='MATERIAL'
         )
-        OperatorFactory.create(
-            sub_layout,
-            'genshin.set_up_outlines',
-            'Set Up Outlines',
-            icon='GEOMETRY_NODES'
-        )
+        if version_number_above_or_equal((3, 3, 0)):
+            OperatorFactory.create(
+                sub_layout,
+                'genshin.set_up_outlines',
+                'Set Up Outlines',
+                icon='GEOMETRY_NODES'
+            )
+        else:
+            layout.label(text='(Outlines Disabled < v3.3.0)')
         OperatorFactory.create(
             sub_layout,
             'genshin.finish_setup',
@@ -156,30 +159,33 @@ class GI_PT_UI_Outlines_Menu(Panel):
         layout = self.layout
         sub_layout = layout.column()
 
-        OperatorFactory.create(
-            sub_layout,
-            'genshin.import_outlines',
-            'Import Outlines',
-            'FILE_FOLDER'
-        )
-        OperatorFactory.create(
-            sub_layout,
-            'genshin.setup_geometry_nodes',
-            'Set Up Geometry Nodes',
-            'GEOMETRY_NODES'
-        )
-        OperatorFactory.create(
-            sub_layout,
-            'genshin.import_outline_lightmaps',
-            'Import Outline Lightmaps',
-            'FILE_FOLDER'
-        )
-        OperatorFactory.create(
-            sub_layout,
-            'genshin.import_material_data',
-            'Import Material Data',
-            'FILE'
-        )
+        if version_number_above_or_equal((3, 3, 0)):
+            OperatorFactory.create(
+                sub_layout,
+                'genshin.import_outlines',
+                'Import Outlines',
+                'FILE_FOLDER'
+            )
+            OperatorFactory.create(
+                sub_layout,
+                'genshin.setup_geometry_nodes',
+                'Set Up Geometry Nodes',
+                'GEOMETRY_NODES'
+            )
+            OperatorFactory.create(
+                sub_layout,
+                'genshin.import_outline_lightmaps',
+                'Import Outline Lightmaps',
+                'FILE_FOLDER'
+            )
+            OperatorFactory.create(
+                sub_layout,
+                'genshin.import_material_data',
+                'Import Material Data',
+                'FILE'
+            )
+        else:
+            layout.label(text='(Outlines Disabled < v3.3.0)')
 
 
 class GI_PT_UI_Finish_Setup_Menu(Panel):
@@ -218,6 +224,16 @@ class GI_PT_UI_Finish_Setup_Menu(Panel):
             'TRASH'
         )
 
+
+def version_number_above_or_equal(required_version_number_tuple):
+    current_version = bpy.app.version
+
+    for index in range(0, len(required_version_number_tuple)):
+        if current_version[index] < required_version_number_tuple[index]:
+            return False
+        elif current_version[index] > required_version_number_tuple[index]:
+            return True
+    return True
 
 
 '''


### PR DESCRIPTION
* Do not render buttons for Outlines if the Blender version is < v3.3.0
* Do not include Outlines in "One-Click" Simplified Setup if the Blender version is < v3.3.0