### PR TITLE
feat: framework and support for multiple material data json formats

### DIFF
--- a/setup_wizard/exceptions.py
+++ b/setup_wizard/exceptions.py
@@ -6,8 +6,3 @@ class UnsupportedMaterialDataJsonFormatException(Exception):
             'Unsupported Material Data Json format detected. ' \
                 f'Supported Material Data Json Formats: {parsers}'
         super().__init__(message)
-
-class MaterialDataValueNotFoundException(Exception):
-    def __init__(self, body_part, material_json_name):
-        message = f'Error! Could not find {material_json_name} in {body_part} JSON file'
-        super().__init__(message)

--- a/setup_wizard/exceptions.py
+++ b/setup_wizard/exceptions.py
@@ -1,0 +1,13 @@
+# Author: michael-gh1
+
+class UnsupportedMaterialDataJsonFormatException(Exception):
+    def __init__(self, parsers):
+        message = 'Unable to determine Material Data Json Parser to use. ' \
+            'Unsupported Material Data Json format detected. ' \
+                f'Supported Material Data Json Formats: {parsers}'
+        super().__init__(message)
+
+class MaterialDataValueNotFoundException(Exception):
+    def __init__(self, body_part, material_json_name):
+        message = f'Error! Could not find {material_json_name} in {body_part} JSON file'
+        super().__init__(message)

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -125,10 +125,7 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
                 if not material_json_value:
                     self.__raise_material_value_not_found(body_part, material_json_name)
 
-                if type(material_node) is bpy.types.NodeSocketColor:
-                    material_node.default_value = material_json_value
-                else:
-                    material_node.default_value = material_json_value
+                material_node.default_value = material_json_value
             
             # Not sure, should we only apply Global Material Properties from Body .dat file?
             if body_part == 'Body':
@@ -139,10 +136,7 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
                     if not material_json_value:
                         self.__raise_material_value_not_found(body_part, material_json_name)
 
-                    if type(material_node) is bpy.types.NodeSocketColor:
-                        material_node.default_value = material_json_value
-                    else:
-                        material_node.default_value = material_json_value
+                    material_node.default_value = material_json_value
 
 
     def set_up_outline_colors(self, material_data_parser, body_part):

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -170,8 +170,9 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
         return getattr(parser.m_floats, key, None) or getattr(parser.m_colors, key, None)
 
     def __handle_material_value_not_found(self, body_part, material_json_name):
-        self.report({'WARNING'}, f'Unable to find material data: {material_json_name} on {body_part}. \n' \
-            'This may or may not be expected. Continuing to apply other material data.')
+        # Log at INFO level because otherwise it may become "just another warning" and get ignored
+        self.report({'INFO'}, f'Unable to find material data: {material_json_name} on {body_part} JSON. \n' \
+            '* This may or may not be expected. Continuing to apply other material data.')
 
 
 register, unregister = bpy.utils.register_classes_factory(GI_OT_GenshinImportMaterialData)

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -10,7 +10,7 @@ from bpy_extras.io_utils import ImportHelper
 from bpy.props import StringProperty, CollectionProperty
 from bpy.types import Operator, PropertyGroup
 import os
-from setup_wizard.exceptions import MaterialDataValueNotFoundException, UnsupportedMaterialDataJsonFormatException
+from setup_wizard.exceptions import UnsupportedMaterialDataJsonFormatException
 
 from setup_wizard.import_order import NextStepInvoker
 from setup_wizard.models import CustomOperatorProperties

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -149,7 +149,8 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
         for material_json_name, material_node_name in material_mapping.items():
             material_json_value = self.__get_value_in_json_parser(material_data_parser, material_json_name)
             if not material_json_value:
-                self.__raise_material_value_not_found(body_part, material_json_name)
+                self.__handle_material_value_not_found(body_part, material_json_name)
+                continue
 
             node_input = node_inputs.get(material_node_name)
             node_input.default_value = material_json_value
@@ -168,9 +169,9 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
     def __get_value_in_json_parser(self, parser, key):
         return getattr(parser.m_floats, key, None) or getattr(parser.m_colors, key, None)
 
-    def __raise_material_value_not_found(self, body_part, material_json_name):
-        self.filepath = ''
-        raise MaterialDataValueNotFoundException(body_part, material_json_name)
+    def __handle_material_value_not_found(self, body_part, material_json_name):
+        self.report({'WARNING'}, f'Unable to find material data: {material_json_name} on {body_part}. \n' \
+            'This may or may not be expected. Continuing to apply other material data.')
 
 
 register, unregister = bpy.utils.register_classes_factory(GI_OT_GenshinImportMaterialData)

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -155,7 +155,6 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             except AttributeError:
                 if index == len(self.parsers) - 1:
                     raise UnsupportedMaterialDataJsonFormatException(self.parsers)
-                continue
 
     def __apply_material_data(self, material_mapping, node_inputs, material_data_parser, body_part):
         for material_json_name, material_node_name in material_mapping.items():

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -118,39 +118,41 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             bpy.data.node_groups["GLOBAL MATERIAL PROPERTIES"].nodes["Group Output"].inputs
 
         if body_part != 'Face':
-            for material_json_name, material_node_name in self.local_material_mapping.items():
-                material_json_value = self.__get_value_in_json_parser(material_data_parser, material_json_name)
-                material_node = node_tree_group001_inputs.get(self.local_material_mapping.get(material_json_name))
-
-                if not material_json_value:
-                    self.__raise_material_value_not_found(body_part, material_json_name)
-
-                material_node.default_value = material_json_value
+            self.__apply_material_data(
+                self.local_material_mapping,
+                node_tree_group001_inputs,
+                material_data_parser,
+                body_part
+            )
             
             # Not sure, should we only apply Global Material Properties from Body .dat file?
             if body_part == 'Body':
-                for material_json_name, material_node_name in self.global_material_mapping.items():
-                    material_json_value = self.__get_value_in_json_parser(material_data_parser, material_json_name)
-                    material_node = global_material_properties_node_inputs.get(self.global_material_mapping.get(material_json_name))
-
-                    if not material_json_value:
-                        self.__raise_material_value_not_found(body_part, material_json_name)
-
-                    material_node.default_value = material_json_value
-
+                self.__apply_material_data(
+                    self.global_material_mapping,
+                    global_material_properties_node_inputs,
+                    material_data_parser,
+                    body_part
+                )
 
     def set_up_outline_colors(self, material_data_parser, body_part):
         outlines_material = bpy.data.materials.get(f'miHoYo - Genshin {body_part} Outlines')
         outlines_shader_node_inputs = outlines_material.node_tree.nodes.get('Group.002').inputs
 
-        for material_json_name, material_node_name in self.outline_mapping.items():
-            material_json_value = self.__get_value_in_json_parser(material_data_parser, material_json_name)
-            shader_node_input = outlines_shader_node_inputs.get(material_node_name)
+        self.__apply_material_data(
+            self.outline_mapping, 
+            outlines_shader_node_inputs,
+            material_data_parser,
+            body_part
+        )
 
+    def __apply_material_data(self, material_mapping, node_inputs, material_data_parser, body_part):
+        for material_json_name, material_node_name in material_mapping.items():
+            material_json_value = self.__get_value_in_json_parser(material_data_parser, material_json_name)
             if not material_json_value:
                 self.__raise_material_value_not_found(body_part, material_json_name)
 
-            shader_node_input.default_value = material_json_value
+            node_input = node_inputs.get(material_node_name)
+            node_input.default_value = material_json_value
 
     def __get_material_data_json_parser(self, json_material_data):
         for index, parser_class in enumerate(self.parsers):

--- a/setup_wizard/parsers/data_classes.py
+++ b/setup_wizard/parsers/data_classes.py
@@ -1,0 +1,9 @@
+# Author: michael-gh1
+
+'''
+    Data class that is used to store values from m_Floats and m_Colors from Material Data Jsons
+'''
+class MaterialData:
+    def __init__(self, json_m_data):
+        for key, value in json_m_data.items():
+            setattr(self, key, value)

--- a/setup_wizard/parsers/material_data_json_parsers.py
+++ b/setup_wizard/parsers/material_data_json_parsers.py
@@ -1,0 +1,90 @@
+# Author: michael-gh1
+
+from abc import ABC, abstractmethod
+
+from setup_wizard.parsers.data_classes import MaterialData
+
+
+class MaterialDataJsonParser(ABC):
+    def __init__(self, json_material_data):
+        self.json_material_data = json_material_data
+
+    @abstractmethod
+    def parse(self, json_material_data):
+        raise NotImplementedError()
+
+
+class HoyoStudioMaterialDataJsonParser(MaterialDataJsonParser):
+    def __init__(self, json_material_data):
+        super().__init__(json_material_data)
+
+    def parse(self):
+        m_colors = self.json_material_data.get('m_SavedProperties').get('m_Colors')
+        m_colors_dict = {}
+        for key, value in m_colors.items():
+            m_colors_dict[key] = self.__get_rgba_colors(value)
+
+        self.m_floats = MaterialData(self.json_material_data.get('m_SavedProperties').get('m_Floats'))
+        self.m_colors = MaterialData(m_colors_dict)
+
+    def __get_rgba_colors(self, material_json_value):
+        # check lowercase for backwards compatibility
+        # explicitly check 'is not None' because rgba values could be Falsy
+        r = material_json_value.get('R') if material_json_value.get('R') is not None else material_json_value.get('r')
+        g = material_json_value.get('G') if material_json_value.get('G') is not None else material_json_value.get('g')
+        b = material_json_value.get('B') if material_json_value.get('B') is not None else material_json_value.get('b')
+        a = material_json_value.get('A') if material_json_value.get('A') is not None else material_json_value.get('a')
+        return (r, g, b, a)
+
+
+class UABEMaterialDataJsonParser(MaterialDataJsonParser):
+    def __init__(self, json_material_data):
+        super().__init__(json_material_data)
+
+    def parse(self):
+        material_base = self.json_material_data.get('0 Material Base')
+        m_saved_properties = material_base.get('0 UnityPropertySheet m_SavedProperties')
+
+        json_m_floats = self.__get_json_m_floats(m_saved_properties)
+        json_m_colors = self.__get_json_m_colors(m_saved_properties)
+        
+        self.m_floats = MaterialData(json_m_floats)
+        self.m_colors = MaterialData(json_m_colors)
+
+    def __get_json_m_floats(self, m_saved_properties):
+        raw_m_floats = m_saved_properties.get('0 map m_Floats').get('0 Array Array')
+        list_of_dict_m_floats = [
+            {raw_m_float_json['0 pair data']['1 string first']: raw_m_float_json['0 pair data']['0 float second']}
+            for raw_m_float_json in raw_m_floats
+        ]  # a list of dictionaries
+
+        json_m_floats = {}
+        for dict_m_float in list_of_dict_m_floats:
+            dict_m_float_key = list(dict_m_float.keys())[0]
+            dict_m_float_value = list(dict_m_float.values())[0]
+
+            json_m_floats[dict_m_float_key] = dict_m_float_value
+        return json_m_floats
+
+    def __get_json_m_colors(self, m_saved_properties):
+        raw_m_colors = m_saved_properties.get('0 map m_Colors').get('0 Array Array')
+        list_of_dict_m_colors = [
+            {raw_m_float_json['0 pair data']['1 string first']: raw_m_float_json['0 pair data']['0 ColorRGBA second']}
+            for raw_m_float_json in raw_m_colors
+        ]  # a list of dictionaries
+
+        json_m_colors = {}
+        for dict_m_color in list_of_dict_m_colors:
+            dict_m_color_key = list(dict_m_color.keys())[0]
+            dict_m_color_value = list(dict_m_color.values())[0]
+
+            json_m_colors[dict_m_color_key] = self.__get_rgba_colors(dict_m_color_value)
+        return json_m_colors
+
+    def __get_rgba_colors(self, material_json_value):
+        prefix = '0 float'
+        r = material_json_value.get(f'{prefix} r')
+        g = material_json_value.get(f'{prefix} g')
+        b = material_json_value.get(f'{prefix} b')
+        a = material_json_value.get(f'{prefix} a')
+        return (r, g, b, a)


### PR DESCRIPTION
* Created HoyoStudio and UABE material JSON parsers
  * To add additional JSON parsers:
    1. Create a new class that inherits `MaterialDataJsonParser`
    2. Write the parsing logic
    3. Add it to the `parsers` list in `genshin_import_material_data.py`
* Refactored component that imports material data
  * duplicate logic consolidated into a single method
* Provide slightly more user-friendly info/error messages