### PR TITLE
feat: decrease default outline thickness and reset custom properties at the end of a component

### DIFF
--- a/setup_wizard/genshin_import_character_model.py
+++ b/setup_wizard/genshin_import_character_model.py
@@ -79,7 +79,7 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
             file_path_to_cache=character_model_folder_file_path,
             high_level_step_name=self.high_level_step_name
         )
-        super().reset()
+        super().clear_state()
         return {'FINISHED'}
 
     def import_character_model(self, character_model_file_path_directory):

--- a/setup_wizard/genshin_import_character_model.py
+++ b/setup_wizard/genshin_import_character_model.py
@@ -73,13 +73,13 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
         if context.window_manager.cache_enabled and character_model_folder_file_path:
             cache_using_cache_key(get_cache(), CHARACTER_MODEL_FOLDER_FILE_PATH, character_model_folder_file_path)
 
-        self.filepath = ''  # Important! UI saves previous choices to the Operator instance
         NextStepInvoker().invoke(
             self.next_step_idx, 
             self.invoker_type, 
             file_path_to_cache=character_model_folder_file_path,
             high_level_step_name=self.high_level_step_name
         )
+        super().reset()
         return {'FINISHED'}
 
     def import_character_model(self, character_model_file_path_directory):

--- a/setup_wizard/genshin_import_character_model.py
+++ b/setup_wizard/genshin_import_character_model.py
@@ -79,7 +79,7 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
             file_path_to_cache=character_model_folder_file_path,
             high_level_step_name=self.high_level_step_name
         )
-        super().clear_state()
+        super().clear_custom_properties()
         return {'FINISHED'}
 
     def import_character_model(self, character_model_file_path_directory):

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -110,12 +110,12 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
                 continue
 
         self.report({'INFO'}, 'Imported material data')
-        self.filepath = ''  # Important! UI saves previous choices to the Operator instance
         NextStepInvoker().invoke(
             self.next_step_idx, 
             self.invoker_type, 
             high_level_step_name=self.high_level_step_name
         )
+        super().reset()
         return {'FINISHED'}
 
     def set_up_mesh_material_data(self, material_data_parser, body_part):

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -100,8 +100,14 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             json_material_data = json.load(fp)
             material_data_parser = self.__get_material_data_json_parser(json_material_data)
 
-            self.set_up_mesh_material_data(material_data_parser, body_part)
-            self.set_up_outline_colors(material_data_parser, body_part)
+            try:
+                self.set_up_mesh_material_data(material_data_parser, body_part)
+                self.set_up_outline_colors(material_data_parser, body_part)
+            except KeyError:
+                self.report({'WARNING'}, \
+                    f'Continuing to apply other material data, but: \n'
+                    f'* Material Data JSON "{body_part}" was selected, but there is no material named "miHoYo - Genshin {body_part}"')
+                continue
 
         self.report({'INFO'}, 'Imported material data')
         self.filepath = ''  # Important! UI saves previous choices to the Operator instance
@@ -114,7 +120,8 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
 
     def set_up_mesh_material_data(self, material_data_parser, body_part):
         if body_part != 'Face':
-            node_tree_group001_inputs = bpy.data.materials[f'miHoYo - Genshin {body_part}'].node_tree.nodes["Group.001"].inputs
+            body_part_material = bpy.data.materials[f'miHoYo - Genshin {body_part}']
+            node_tree_group001_inputs = body_part_material.node_tree.nodes["Group.001"].inputs
 
             self.__apply_material_data(
                 self.local_material_mapping,
@@ -136,7 +143,7 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             )
 
     def set_up_outline_colors(self, material_data_parser, body_part):
-        outlines_material = bpy.data.materials.get(f'miHoYo - Genshin {body_part} Outlines')
+        outlines_material = bpy.data.materials[f'miHoYo - Genshin {body_part} Outlines']
         outlines_shader_node_inputs = outlines_material.node_tree.nodes.get('Group.002').inputs
 
         self.__apply_material_data(

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -115,7 +115,7 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             self.invoker_type, 
             high_level_step_name=self.high_level_step_name
         )
-        super().reset()
+        super().clear_state()
         return {'FINISHED'}
 
     def set_up_mesh_material_data(self, material_data_parser, body_part):

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -115,7 +115,7 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             self.invoker_type, 
             high_level_step_name=self.high_level_step_name
         )
-        super().clear_state()
+        super().clear_custom_properties()
         return {'FINISHED'}
 
     def set_up_mesh_material_data(self, material_data_parser, body_part):

--- a/setup_wizard/genshin_import_materials.py
+++ b/setup_wizard/genshin_import_materials.py
@@ -81,13 +81,13 @@ class GI_OT_GenshinImportMaterials(Operator, ImportHelper, CustomOperatorPropert
         if cache_enabled and project_root_directory_file_path:
             cache_using_cache_key(get_cache(cache_enabled), FESTIVITY_ROOT_FOLDER_FILE_PATH, project_root_directory_file_path)
 
-        self.filepath = ''  # Important! UI saves previous choices to the Operator instance
         NextStepInvoker().invoke(
             self.next_step_idx, 
             self.invoker_type, 
             file_path_to_cache=project_root_directory_file_path,
             high_level_step_name=self.high_level_step_name
         )
+        super().reset()
         return {'FINISHED'}
 
 

--- a/setup_wizard/genshin_import_materials.py
+++ b/setup_wizard/genshin_import_materials.py
@@ -87,7 +87,7 @@ class GI_OT_GenshinImportMaterials(Operator, ImportHelper, CustomOperatorPropert
             file_path_to_cache=project_root_directory_file_path,
             high_level_step_name=self.high_level_step_name
         )
-        super().clear_state()
+        super().clear_custom_properties()
         return {'FINISHED'}
 
 

--- a/setup_wizard/genshin_import_materials.py
+++ b/setup_wizard/genshin_import_materials.py
@@ -87,7 +87,7 @@ class GI_OT_GenshinImportMaterials(Operator, ImportHelper, CustomOperatorPropert
             file_path_to_cache=project_root_directory_file_path,
             high_level_step_name=self.high_level_step_name
         )
-        super().reset()
+        super().clear_state()
         return {'FINISHED'}
 
 

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -79,7 +79,7 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
             file_path_to_cache=character_model_folder_file_path,
             high_level_step_name=self.high_level_step_name
         )
-        super().clear_state()
+        super().clear_custom_properties()
         return {'FINISHED'}
 
 

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -73,13 +73,13 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
         if cache_enabled and character_model_folder_file_path:
             cache_using_cache_key(get_cache(cache_enabled), CHARACTER_MODEL_FOLDER_FILE_PATH, character_model_folder_file_path)
 
-        self.filepath = ''  # Important! UI saves previous choices to the Operator instance
         NextStepInvoker().invoke(
             self.next_step_idx, 
             self.invoker_type, 
             file_path_to_cache=character_model_folder_file_path,
             high_level_step_name=self.high_level_step_name
         )
+        super().reset()
         return {'FINISHED'}
 
 

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -79,7 +79,7 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
             file_path_to_cache=character_model_folder_file_path,
             high_level_step_name=self.high_level_step_name
         )
-        super().reset()
+        super().clear_state()
         return {'FINISHED'}
 
 

--- a/setup_wizard/genshin_import_outlines.py
+++ b/setup_wizard/genshin_import_outlines.py
@@ -64,12 +64,12 @@ class GI_OT_GenshinImportOutlines(Operator, ImportHelper, CustomOperatorProperti
             if cache_enabled and filepath:
                 cache_using_cache_key(get_cache(cache_enabled), FESTIVITY_OUTLINES_FILE_PATH, filepath)
 
-        self.filepath = ''  # Important! UI saves previous choices to the Operator instance
         NextStepInvoker().invoke(
             self.next_step_idx, 
             self.invoker_type,
             high_level_step_name=self.high_level_step_name
         )
+        super().reset()
         return {'FINISHED'}
 
 

--- a/setup_wizard/genshin_import_outlines.py
+++ b/setup_wizard/genshin_import_outlines.py
@@ -69,7 +69,7 @@ class GI_OT_GenshinImportOutlines(Operator, ImportHelper, CustomOperatorProperti
             self.invoker_type,
             high_level_step_name=self.high_level_step_name
         )
-        super().reset()
+        super().clear_state()
         return {'FINISHED'}
 
 

--- a/setup_wizard/genshin_import_outlines.py
+++ b/setup_wizard/genshin_import_outlines.py
@@ -69,7 +69,7 @@ class GI_OT_GenshinImportOutlines(Operator, ImportHelper, CustomOperatorProperti
             self.invoker_type,
             high_level_step_name=self.high_level_step_name
         )
-        super().clear_state()
+        super().clear_custom_properties()
         return {'FINISHED'}
 
 

--- a/setup_wizard/genshin_import_textures.py
+++ b/setup_wizard/genshin_import_textures.py
@@ -135,7 +135,7 @@ class GI_OT_GenshinImportTextures(Operator, ImportHelper, CustomOperatorProperti
             file_path_to_cache=directory,
             high_level_step_name=self.high_level_step_name
         )
-        super().reset()
+        super().clear_state()
         return {'FINISHED'}
 
     def plug_normal_map(self, shader_material_name, label_name):

--- a/setup_wizard/genshin_import_textures.py
+++ b/setup_wizard/genshin_import_textures.py
@@ -135,7 +135,7 @@ class GI_OT_GenshinImportTextures(Operator, ImportHelper, CustomOperatorProperti
             file_path_to_cache=directory,
             high_level_step_name=self.high_level_step_name
         )
-        super().clear_state()
+        super().clear_custom_properties()
         return {'FINISHED'}
 
     def plug_normal_map(self, shader_material_name, label_name):

--- a/setup_wizard/genshin_import_textures.py
+++ b/setup_wizard/genshin_import_textures.py
@@ -129,13 +129,13 @@ class GI_OT_GenshinImportTextures(Operator, ImportHelper, CustomOperatorProperti
         if cache_enabled and directory:
             cache_using_cache_key(get_cache(cache_enabled), CHARACTER_MODEL_FOLDER_FILE_PATH, directory)
 
-        self.filepath = ''  # Important! UI saves previous choices to the Operator instance
         NextStepInvoker().invoke(
             self.next_step_idx,
             self.invoker_type,
             file_path_to_cache=directory,
             high_level_step_name=self.high_level_step_name
         )
+        super().reset()
         return {'FINISHED'}
 
     def plug_normal_map(self, shader_material_name, label_name):

--- a/setup_wizard/genshin_set_up_geometry_nodes.py
+++ b/setup_wizard/genshin_set_up_geometry_nodes.py
@@ -101,6 +101,7 @@ class GI_OT_SetUpGeometryNodes(Operator, CustomOperatorProperties):
                 modifier_name=modifier.name)
 
         modifier[f'{NAME_OF_VERTEX_COLORS_INPUT}_attribute_name'] = 'Col'
+        modifier[OUTLINE_THICKNESS_INPUT] = 0.25
 
         if mesh.name == 'Face_Eye':
             self.disable_face_eye_outlines(modifier)

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -25,7 +25,7 @@ class NextStepInvoker:
         elif type == 'invoke_next_step_ui':
             invoke_next_step_ui(high_level_step_name, current_step_index)
         else:
-            print(f'Warn: Unknown type found when invoking: {type}')
+            print(f'Warning: Unknown type found when invoking: {type}')
 
 
 def invoke_next_step(current_step_idx: int, file_path_to_cache=None):

--- a/setup_wizard/models.py
+++ b/setup_wizard/models.py
@@ -17,7 +17,7 @@ class CustomOperatorProperties:
     Scenario: After running Setup Wizard, Import Material Data would run the next steps in the Setup Wizard.
     This would occur despite running the individual component in Advanced Setup.
     '''
-    def reset(self):
+    def clear_state(self):
         self.filepath = ''  # Important! UI saves previous choices to the Operator instance
         self.next_step_idx = -1
         self.file_directory = ''

--- a/setup_wizard/models.py
+++ b/setup_wizard/models.py
@@ -17,7 +17,7 @@ class CustomOperatorProperties:
     Scenario: After running Setup Wizard, Import Material Data would run the next steps in the Setup Wizard.
     This would occur despite running the individual component in Advanced Setup.
     '''
-    def clear_state(self):
+    def clear_custom_properties(self):
         self.filepath = ''  # Important! UI saves previous choices to the Operator instance
         self.next_step_idx = -1
         self.file_directory = ''

--- a/setup_wizard/models.py
+++ b/setup_wizard/models.py
@@ -10,6 +10,20 @@ class CustomOperatorProperties:
     invoker_type: StringProperty()
     high_level_step_name: StringProperty()
 
+    '''
+    Modules will be registered and store previous choices within the same Blender file instance/session.
+    This method will reset all values in the module in order for previous state to persist.
+    
+    Scenario: After running Setup Wizard, Import Material Data would run the next steps in the Setup Wizard.
+    This would occur despite running the individual component in Advanced Setup.
+    '''
+    def reset(self):
+        self.filepath = ''  # Important! UI saves previous choices to the Operator instance
+        self.next_step_idx = -1
+        self.file_directory = ''
+        self.invoker_type = ''
+        self.high_level_step_name = ''
+
 
 class BasicSetupUIOperator:
     def execute(self, context):


### PR DESCRIPTION
* Decreased default outline thickness from `1.0` to `0.25` after recent shader change
  * https://github.com/festivize/Blender-miHoYo-Shaders/commit/bbf6c8f22fea9f5b20b5562123243a5666a51294
* Reset custom properties at the end of components that take in user file/folder selections
  * Unexpected state behavior was occurring because the module is registered and values carry over from one usage to the next usage
  * Running the `Entire Setup Wizard` and then running individual components would result in running every step after the individual component too
  * For example, running `Entire Setup Wizard` and then `Import Material Data` would also result in `Fix Transformations` to be run
* Added a warning message when the user selects a Material Data JSON that does not match up with a Material (ex. 'Emission' gets selected, but there is no 'miHoYo - Genshin Emission' material)