### PR TITLE
refacor/fix: handle new characters

### DIFF
--- a/setup_wizard/genshin_import_character_model.py
+++ b/setup_wizard/genshin_import_character_model.py
@@ -65,8 +65,9 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
         # Hide EffectMesh (gets deleted later on) and EyeStar
         # Now shoving in adding UV1 map too...
         for object in bpy.data.objects:
-            if object.name == 'EffectMesh' or object.name == 'EyeStar':
+            if 'EffectMesh' in object.name or 'EyeStar' in object.name:
                 bpy.data.objects[object.name].hide_set(True)
+                bpy.data.objects[object.name].hide_render = True
             if object.type == 'MESH':  # I think this only matters for Body? But adding to all anyways
                 object.data.uv_layers.new(name='UV1')
 

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -59,7 +59,7 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
                 body_part_material_name = outline_material.name.split(' ')[-2]  # ex. 'miHoYo - Genshin Hair Outlines'
                 original_material_name = [material for material in bpy.data.materials if material.name.endswith(f'Mat_{body_part_material_name}')][0]  # from original model
                 material_part_name = get_actual_material_name_for_dress(original_material_name.name)
-                if material_part_name != 'Face':
+                if 'Face' not in material_part_name and 'Face' not in body_part_material_name:
                     file = [file for file in lightmap_files if material_part_name in file][0]
 
                     img_path = character_model_folder_file_path + "/" + file

--- a/setup_wizard/genshin_import_textures.py
+++ b/setup_wizard/genshin_import_textures.py
@@ -58,65 +58,57 @@ class GI_OT_GenshinImportTextures(Operator, ImportHelper, CustomOperatorProperti
                 img_path = directory + "/" + file
                 img = bpy.data.images.load(filepath = img_path, check_existing=True)
                 img.alpha_mode = 'CHANNEL_PACKED'
-                
-                # declare body and face mesh variables
-                body_mesh = bpy.context.scene.objects.get("Body")
-                face_mesh = bpy.context.scene.objects.get("Face")
+
+                hair_material = bpy.data.materials.get('miHoYo - Genshin Hair')
+                face_material = bpy.data.materials.get('miHoYo - Genshin Face')
+                body_material = bpy.data.materials.get('miHoYo - Genshin Body')
                 
                 # Implement the texture in the correct node
                 self.report({'INFO'}, f'Importing texture {file}')
                 if "Hair_Diffuse" in file :
-                    bpy.context.view_layer.objects.active = body_mesh
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Hair').material.node_tree.nodes['Hair_Diffuse_UV0'].image = img
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Hair').material.node_tree.nodes['Hair_Diffuse_UV1'].image = img
+                    hair_material.node_tree.nodes['Hair_Diffuse_UV0'].image = img
+                    hair_material.node_tree.nodes['Hair_Diffuse_UV1'].image = img
                     self.setup_dress_textures('Hair_Diffuse', img)
                 elif "Hair_Lightmap" in file :
-                    bpy.context.view_layer.objects.active = body_mesh
                     img.colorspace_settings.name='Non-Color'
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Hair').material.node_tree.nodes['Hair_Lightmap_UV0'].image = img
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Hair').material.node_tree.nodes['Hair_Lightmap_UV1'].image = img
+                    hair_material.node_tree.nodes['Hair_Lightmap_UV0'].image = img
+                    hair_material.node_tree.nodes['Hair_Lightmap_UV1'].image = img
                     self.setup_dress_textures('Hair_Lightmap', img)
                 elif "Hair_Normalmap" in file :
-                    bpy.context.view_layer.objects.active = body_mesh
                     img.colorspace_settings.name='Non-Color'
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Hair').material.node_tree.nodes['Hair_Normalmap_UV0'].image = img
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Hair').material.node_tree.nodes['Hair_Normalmap_UV1'].image = img
+                    hair_material.node_tree.nodes['Hair_Normalmap_UV0'].image = img
+                    hair_material.node_tree.nodes['Hair_Normalmap_UV1'].image = img
                     self.setup_dress_textures('Hair_Normalmap', img)
                     self.plug_normal_map('miHoYo - Genshin Hair', 'MUTE IF ONLY 1 UV MAP EXISTS')
                 elif "Hair_Shadow_Ramp" in file :
                     bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
                 elif "Body_Diffuse" in file :
-                    bpy.context.view_layer.objects.active = body_mesh
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Body').material.node_tree.nodes['Body_Diffuse_UV0'].image = img
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Body').material.node_tree.nodes['Body_Diffuse_UV1'].image = img
+                    body_material.node_tree.nodes['Body_Diffuse_UV0'].image = img
+                    body_material.node_tree.nodes['Body_Diffuse_UV1'].image = img
                     self.setup_dress_textures('Body_Diffuse', img)
                 elif "Body_Lightmap" in file :
-                    bpy.context.view_layer.objects.active = body_mesh
                     img.colorspace_settings.name='Non-Color'
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Body').material.node_tree.nodes['Body_Lightmap_UV0'].image = img
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Body').material.node_tree.nodes['Body_Lightmap_UV1'].image = img
+                    body_material.node_tree.nodes['Body_Lightmap_UV0'].image = img
+                    body_material.node_tree.nodes['Body_Lightmap_UV1'].image = img
                     self.setup_dress_textures('Body_Lightmap', img)
                 elif "Body_Normalmap" in file :
-                    bpy.context.view_layer.objects.active = body_mesh
                     img.colorspace_settings.name='Non-Color'
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Body').material.node_tree.nodes['Body_Normalmap_UV0'].image = img
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Body').material.node_tree.nodes['Body_Normalmap_UV1'].image = img
+                    body_material.node_tree.nodes['Body_Normalmap_UV0'].image = img
+                    body_material.node_tree.nodes['Body_Normalmap_UV1'].image = img
                     self.setup_dress_textures('Body_Normalmap', img)
                     self.plug_normal_map('miHoYo - Genshin Body', 'MUTE IF ONLY 1 UV MAP EXISTS')
+                    self.plug_normal_map('miHoYo - Genshin Dress', 'MUTE IF ONLY 1 UV MAP EXISTS')
                 elif "Body_Shadow_Ramp" in file :
                     bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
                 elif "Body_Specular_Ramp" in file or "Tex_Specular_Ramp" in file :
                     img.colorspace_settings.name='Non-Color'
                     bpy.data.node_groups['Body Specular Ramp'].nodes['Body_Specular_Ramp'].image = img
                 elif "Face_Diffuse" in file :
-                    bpy.context.view_layer.objects.active = face_mesh if face_mesh else body_mesh
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Face').material.node_tree.nodes['Face_Diffuse'].image = img
+                    face_material.node_tree.nodes['Face_Diffuse'].image = img
                 elif "Face_Shadow" in file :
-                    bpy.context.view_layer.objects.active = face_mesh if face_mesh else body_mesh
                     img.colorspace_settings.name='Non-Color'
-                    bpy.context.object.material_slots.get('miHoYo - Genshin Face').material.node_tree.nodes['Face_Shadow'].image = img
+                    face_material.node_tree.nodes['Face_Shadow'].image = img
                 elif "FaceLightmap" in file :
-                    bpy.context.view_layer.objects.active = face_mesh if face_mesh else body_mesh
                     img.colorspace_settings.name='Non-Color'
                     bpy.data.node_groups['Face Lightmap'].nodes['Face_Lightmap'].image = img
                 elif "MetalMap" in file :
@@ -142,14 +134,15 @@ class GI_OT_GenshinImportTextures(Operator, ImportHelper, CustomOperatorProperti
         shader_group_material_name = 'Group.001'
         shader_material = bpy.data.materials.get(shader_material_name)
 
-        normal_map_node_color_output = [node.outputs.get('Color') for node in shader_material.node_tree.nodes \
-            if node.label == label_name and not node.outputs.get('Color').is_linked][0]
-        normal_map_input = shader_material.node_tree.nodes.get(shader_group_material_name).inputs.get('Normal Map')
+        if shader_material:
+            normal_map_node_color_output = [node.outputs.get('Color') for node in shader_material.node_tree.nodes \
+                if node.label == label_name and not node.outputs.get('Color').is_linked][0]
+            normal_map_input = shader_material.node_tree.nodes.get(shader_group_material_name).inputs.get('Normal Map')
 
-        bpy.data.materials.get(shader_material_name).node_tree.links.new(
-            normal_map_node_color_output,
-            normal_map_input
-        )
+            bpy.data.materials.get(shader_material_name).node_tree.links.new(
+                normal_map_node_color_output,
+                normal_map_input
+            )
     
     def setup_dress_textures(self, texture_name, texture_img):
         shader_dress_materials = [material for material in bpy.data.materials if 'Genshin Dress' in material.name]

--- a/setup_wizard/genshin_set_up_geometry_nodes.py
+++ b/setup_wizard/genshin_set_up_geometry_nodes.py
@@ -49,8 +49,10 @@ class GI_OT_SetUpGeometryNodes(Operator, CustomOperatorProperties):
     def setup_geometry_nodes(self, next_step_idx):
         self.clone_outlines()
         for mesh_name in meshes_to_create_geometry_nodes_on:
-            self.create_geometry_nodes_modifier(f'{mesh_name}{BODY_PART_SUFFIX}')
-            self.fix_meshes_by_setting_genshin_materials(mesh_name)
+            for object_name, object_data in bpy.context.scene.objects.items():
+                if mesh_name in object_name and object_data.type == 'MESH':
+                    self.create_geometry_nodes_modifier(f'{object_name}{BODY_PART_SUFFIX}')
+                    self.fix_meshes_by_setting_genshin_materials(object_name)
 
         if next_step_idx:
             NextStepInvoker().invoke(

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -133,11 +133,17 @@ def clear_cache():
 def get_actual_material_name_for_dress(material_name):
     for material in bpy.data.materials:
         if material_name in material.name:
-            # ex. 'Avatar_Lady_Pole_Rosaria_Tex_Body_Diffuse.png'
-            base_color_texture_image_name = material.node_tree.nodes['Principled BSDF'].inputs['Base Color'].links[0].from_node.image.name_full
-            actual_material_name = base_color_texture_image_name.split('_')[-2]
-            actual_material_name = actual_material_name if actual_material_name else 'Hair' \
-                if 'Hair' in base_color_texture_image_name else 'Body'  # fallback method to get mat name
+            try:
+                # ex. 'Avatar_Lady_Pole_Rosaria_Tex_Body_Diffuse.png'
+                base_color_texture_image_name = material.node_tree.nodes['Principled BSDF'].inputs['Base Color'].links[0].from_node.image.name_full
+                actual_material_name = base_color_texture_image_name.split('_')[-2]
+                actual_material_name = actual_material_name if actual_material_name else 'Hair' \
+                    if 'Hair' in base_color_texture_image_name else 'Body'  # fallback method to get mat name
+            except IndexError:
+                # ex. 'Diffuse Texture.001'
+                actual_material_name = material_name.split('_')[-1]
+                actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
+                print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
             return actual_material_name
 
 

--- a/setup_wizard/misc_operations.py
+++ b/setup_wizard/misc_operations.py
@@ -33,11 +33,12 @@ class GI_OT_DeleteSpecificObjects(Operator, CustomOperatorProperties):
         scene = bpy.context.scene
         objects_to_delete = [
             'EffectMesh'
-        ]
+        ]  # be extremely careful, we will be deleting anything that contains these object names
 
         for object in scene.objects:
-            if object.name in objects_to_delete:
-                bpy.data.objects.remove(object)
+            for object_to_delete in objects_to_delete:
+                if object_to_delete in object.name and object.type == 'MESH':
+                    bpy.data.objects.remove(object)
 
         if self.next_step_idx:
             NextStepInvoker().invoke(


### PR DESCRIPTION
* New character meshes are named differently (numbered) so check if the expected mesh name is in the object name instead of an exact object name check
  * `object.name == 'EffectMesh'` vs `'EffectMesh' in object.name`
* Refactored importing character textures to use `bpy.data.materials` instead of `bpy.context`
  * This allows us to access and update the material directly instead of relying on the active object (which is a little more difficult with the new characters and their numbered mesh format)