### PR TITLE
fix: incorrect mesh name format to create outlines on

### DIFF
--- a/setup_wizard/genshin_set_up_geometry_nodes.py
+++ b/setup_wizard/genshin_set_up_geometry_nodes.py
@@ -50,7 +50,7 @@ class GI_OT_SetUpGeometryNodes(Operator, CustomOperatorProperties):
         self.clone_outlines()
         for mesh_name in meshes_to_create_geometry_nodes_on:
             for object_name, object_data in bpy.context.scene.objects.items():
-                if object_data.type == 'MESH' and (mesh_name == object_name or f'{mesh_name}.' in object_name):
+                if object_data.type == 'MESH' and (mesh_name == object_name or f'_{mesh_name}' in object_name):
                     self.create_geometry_nodes_modifier(f'{object_name}{BODY_PART_SUFFIX}')
                     self.fix_meshes_by_setting_genshin_materials(object_name)
 


### PR DESCRIPTION
Quick fix. We should be searching for `###_{mesh_name}` not `{mesh_name}.###` for some character(s) when creating geometry nodes (outlines) for them.

The issue ended up causing no outlines to be created, which is not a catastrophic issue, but you'd need to then manually set up the outlines for them.