### PR TITLE
feat: support for festivity shader rewrite

### DIFF
--- a/setup_wizard/__init__.py
+++ b/setup_wizard/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Genshin Setup Wizard",
     "author": "Mken",
-    "version": (1, 1, 1),
+    "version": (1, 1, 3),
     "blender": (2, 80, 0),
     "location": "3D View > Sidebar > Genshin Impact Setup Wizard",
     "description": "An addon to streamline the character model setup process when using Festivity's Shaders",

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -67,7 +67,16 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
                     img.alpha_mode = 'CHANNEL_PACKED'
 
                     self.report({'INFO'}, f'Importing lightmap texture "{file}" onto material "{outline_material.name}"')
-                    bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get('Image Texture').image = img
+
+                    # TODO: Refactor. Also, we need to assign Diffuse
+                    old_lightmap_node_name = 'Image Texture'
+                    rewrite_lightmap_node_name = 'Outline_Lightmap'
+
+                    lightmap_node = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(old_lightmap_node_name) \
+                        if bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(old_lightmap_node_name) \
+                            else bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(rewrite_lightmap_node_name)
+
+                    lightmap_node.image = img
             break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files
 
         if cache_enabled and character_model_folder_file_path:

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -59,6 +59,7 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
                 body_part_material_name = outline_material.name.split(' ')[-2]  # ex. 'miHoYo - Genshin Hair Outlines'
                 original_material_name = [material for material in bpy.data.materials if material.name.endswith(f'Mat_{body_part_material_name}')][0]  # from original model
                 material_part_name = get_actual_material_name_for_dress(original_material_name.name)
+
                 if 'Face' not in material_part_name and 'Face' not in body_part_material_name:
                     file = [file for file in lightmap_files if material_part_name in file][0]
 
@@ -75,8 +76,20 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
                     lightmap_node = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(old_lightmap_node_name) \
                         if bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(old_lightmap_node_name) \
                             else bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(rewrite_lightmap_node_name)
-
                     lightmap_node.image = img
+
+                    rewrite_difuse_node_name = 'Outline_Diffuse'
+                    diffuse_node = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(rewrite_difuse_node_name) \
+                        if bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(rewrite_difuse_node_name) \
+                            else None
+                    if diffuse_node:
+                        print(body_part_material_name)
+                        # TODO: Refactor this logic as it's common with the Lightmap img
+                        diffuse_file = [file for file in files if 'Diffuse' in file and f'{material_part_name}' in file][0]
+                        diffuse_img_path = character_model_folder_file_path + "/" + diffuse_file
+                        diffuse_img = bpy.data.images.load(filepath = diffuse_img_path, check_existing=True)
+                        diffuse_img.alpha_mode = 'CHANNEL_PACKED'
+                        diffuse_node.image = diffuse_img
             break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files
 
         if cache_enabled and character_model_folder_file_path:

--- a/setup_wizard/genshin_import_textures.py
+++ b/setup_wizard/genshin_import_textures.py
@@ -130,19 +130,26 @@ class GI_OT_GenshinImportTextures(Operator, ImportHelper, CustomOperatorProperti
         super().clear_custom_properties()
         return {'FINISHED'}
 
+    '''
+    Deprecated: No longer needed after shader rewrite because normal map is plugged by default
+    Still maintains backward compatibility by only trying this if `label_name` is found in the node tree.
+    '''
     def plug_normal_map(self, shader_material_name, label_name):
         shader_group_material_name = 'Group.001'
         shader_material = bpy.data.materials.get(shader_material_name)
 
         if shader_material:
-            normal_map_node_color_output = [node.outputs.get('Color') for node in shader_material.node_tree.nodes \
-                if node.label == label_name and not node.outputs.get('Color').is_linked][0]
-            normal_map_input = shader_material.node_tree.nodes.get(shader_group_material_name).inputs.get('Normal Map')
+            normal_map_node_color_outputs = [node.outputs.get('Color') for node in shader_material.node_tree.nodes \
+                if node.label == label_name and not node.outputs.get('Color').is_linked]
+            
+            if normal_map_node_color_outputs:
+                normal_map_node_color_output = normal_map_node_color_outputs[0]
+                normal_map_input = shader_material.node_tree.nodes.get(shader_group_material_name).inputs.get('Normal Map')
 
-            bpy.data.materials.get(shader_material_name).node_tree.links.new(
-                normal_map_node_color_output,
-                normal_map_input
-            )
+                bpy.data.materials.get(shader_material_name).node_tree.links.new(
+                    normal_map_node_color_output,
+                    normal_map_input
+                )
     
     def setup_dress_textures(self, texture_name, texture_img):
         shader_dress_materials = [material for material in bpy.data.materials if 'Genshin Dress' in material.name]

--- a/setup_wizard/genshin_setup_wizard.py
+++ b/setup_wizard/genshin_setup_wizard.py
@@ -6,7 +6,6 @@ from bpy.types import Operator
 from setup_wizard.import_order import NextStepInvoker
 
 from setup_wizard.models import BasicSetupUIOperator
-from setup_wizard.ui_setup_wizard_menu import version_number_above_or_equal
 
 
 class GI_OT_GenshinSetupWizardUI(Operator, BasicSetupUIOperator):
@@ -20,7 +19,7 @@ class GI_OT_GenshinSetupWizardUI(Operator, BasicSetupUIOperator):
         NextStepInvoker().invoke(
             next_step_index,
             'invoke_next_step_ui', 
-            high_level_step_name=self.bl_idname if version_number_above_or_equal((3, 3, 0)) \
+            high_level_step_name=self.bl_idname if bpy.app.version >= (3,3,0) >= (3,3,0) \
                 else self.bl_idname + '_no_outlines'
         )
         return {'FINISHED'}

--- a/setup_wizard/ui_setup_wizard_menu.py
+++ b/setup_wizard/ui_setup_wizard_menu.py
@@ -63,7 +63,7 @@ class GI_PT_Basic_Setup_Wizard_UI_Layout(Panel):
             'Set Up Materials',
             icon='MATERIAL'
         )
-        if version_number_above_or_equal((3, 3, 0)):
+        if bpy.app.version >= (3,3,0):
             OperatorFactory.create(
                 sub_layout,
                 'genshin.set_up_outlines',
@@ -159,7 +159,7 @@ class GI_PT_UI_Outlines_Menu(Panel):
         layout = self.layout
         sub_layout = layout.column()
 
-        if version_number_above_or_equal((3, 3, 0)):
+        if bpy.app.version >= (3,3,0):
             OperatorFactory.create(
                 sub_layout,
                 'genshin.import_outlines',
@@ -223,17 +223,6 @@ class GI_PT_UI_Finish_Setup_Menu(Panel):
             'Delete EffectMesh',
             'TRASH'
         )
-
-
-def version_number_above_or_equal(required_version_number_tuple):
-    current_version = bpy.app.version
-
-    for index in range(0, len(required_version_number_tuple)):
-        if current_version[index] < required_version_number_tuple[index]:
-            return False
-        elif current_version[index] > required_version_number_tuple[index]:
-            return True
-    return True
 
 
 '''


### PR DESCRIPTION
Pre-Release early access support for Festivity's shader rewrite.

- No longer need to plug normal map
- Outline lightmap node was renamed
- A new node for diffuse texture be assigned for Outlines
- Material data - tons of new values and some old ones were renamed or removed