### PR TITLE
feat: ability to select blend file with materials and some refactoring

### DIFF
--- a/setup_wizard/README.md
+++ b/setup_wizard/README.md
@@ -51,10 +51,9 @@ Download Tutorials:
 6. Click the `Run Entire Setup` button
     * Outlines are supported for Blender Version >= 3.3 (you can either disable the outline-related components or use the Basic Setup instead)
 7. Select the folder with the character model and textures (lightmaps, diffuses, etc.)
-8. Select the root/base folder with Festivity's Shaders 
+8. Select the blend file containing with Festivity's Shaders 
     * **This only needs to be done the first time you run this tool.** This is because the filepath gets cached for future usage (click the clear cache button if you want to reset this value).
-    * Double click to navigate inside the folder to select it, do not select a specific file inside!
-    * Ex. My shaders are in a folder called `Blender-miHoYo-Shaders`
+    * Ex. `miHoYo - Genshin Impact.blend` or `miHoYo - Genshin Impact - Goo Engine.blend`
 9. Select the `miHoYo - Outlines.blend` file (located in Festivity's Shaders `experimental-blender-3.3` folder)
     * **This only needs to be done the first time you run this tool.** This is because the filepath gets cached for future usage (click the clear cache button if you want to reset this value).
     * Ex. `Blender-miHoYo-Shaders/experimental-blender-3.3/miHoYo - Outlines.blend`
@@ -104,7 +103,10 @@ You can disable the cache for any step by unchecking the `Cache Enabled` checkbo
         * Saves the character model folder file path selected
         * You may want to disable the cache if you are importing textures that are different from the character model (not the usual workflow)
         * Used when importing textures and outline lightmaps
-    * Festivity Root/Base Folder File Path
+    * Festivity Shader Blend File Path
+        * Saves the file path to Festivity's shader blend file
+        * Used when importing materials either: `miHoYo - Genshin Impact.blend` or `miHoYo - Genshin Impact - Goo Engine.blend`
+    * **(Deprecated)** Festivity Root/Base Folder File Path
         * Saves the file path to Festivity's shaders folder
         * Used when importing materials from `miHoYo - Genshin Impact.blend`
     * Festivity Outlines File Path
@@ -163,7 +165,8 @@ You can disable the cache for any step by unchecking the `Cache Enabled` checkbo
 3. Import Materials
     * This step imports `miHoYo - Genshin Hair`, `miHoYo - Genshin Face`, `miHoYo - Genshin Body` and `miHoYo - Genshin Outlines`.
     * **This step uses the cache (if enabled)** so you do not need to re-select the `miHoYo - Genshin Impact.blend` after selecting it on first use.
-    * Select the root folder that contains Festivity's Shaders.
+    * Select the blend file containing Festivity's Shaders `miHoYo - Genshin Impact.blend` or `miHoYo - Genshin Impact - Goo Engine.blend`.
+        * (**Deprecated**) Select the root folder that contains Festivity's Shaders.
 4. Replace Default Character Model Materials (and rename)
     * This step replaces/re-assigns the default character model materials to the shader's materials.
     * Naming Convention of Genshin Materials (and their Shader nodes): `miHoYo - Genshin {Body Part}` 

--- a/setup_wizard/genshin_import_materials.py
+++ b/setup_wizard/genshin_import_materials.py
@@ -31,16 +31,16 @@ class GI_OT_SetUpMaterials(Operator, BasicSetupUIOperator):
 
 
 class GI_OT_GenshinImportMaterials(Operator, ImportHelper, CustomOperatorProperties):
-    """Select Festivity's Shaders folder to import materials"""
+    """Select Festivity's Shader .blend File to import materials"""
     bl_idname = "genshin.import_materials"  # important since its how we chain file dialogs
-    bl_label = "Genshin: Import Materials - Select Festivity's Shaders Folder"
+    bl_label = "Genshin: Import Materials - Select Festivity's .blend File"
 
     # ImportHelper mixin class uses this
     filename_ext = "*.*"
 
     import_path: StringProperty(
         name="Path",
-        description="Path to the folder of Festivity's Shaders project",
+        description="Festivity's Shader .blend File",
         default="",
         subtype='DIR_PATH'
     )

--- a/setup_wizard/genshin_import_materials.py
+++ b/setup_wizard/genshin_import_materials.py
@@ -9,7 +9,8 @@ from bpy.props import StringProperty
 from bpy.types import Operator
 import os
 
-from setup_wizard.import_order import FESTIVITY_ROOT_FOLDER_FILE_PATH, NextStepInvoker, cache_using_cache_key, get_cache
+from setup_wizard.import_order import NextStepInvoker, cache_using_cache_key, get_cache, \
+    FESTIVITY_ROOT_FOLDER_FILE_PATH, FESTIVITY_SHADER_FILE_PATH
 from setup_wizard.models import BasicSetupUIOperator, CustomOperatorProperties
 
 DEFAULT_BLEND_FILE_WITH_GENSHIN_MATERIALS = 'miHoYo - Genshin Impact.blend'
@@ -52,11 +53,15 @@ class GI_OT_GenshinImportMaterials(Operator, ImportHelper, CustomOperatorPropert
 
     def execute(self, context):
         cache_enabled = context.window_manager.cache_enabled
+        user_selected_shader_blend_file_path = self.filepath if self.filepath and not os.path.isdir(self.filepath) \
+            else get_cache(cache_enabled).get(FESTIVITY_SHADER_FILE_PATH)
         project_root_directory_file_path = self.file_directory \
             or get_cache(cache_enabled).get(FESTIVITY_ROOT_FOLDER_FILE_PATH) \
             or os.path.dirname(self.filepath)
 
-        if not project_root_directory_file_path:
+        if not user_selected_shader_blend_file_path and not project_root_directory_file_path:
+            # Use Case: Advanced Setup
+            # The Operator is Executed directly with no cached files and so we need to Invoke to prompt the user
             bpy.ops.genshin.import_materials(
                 'INVOKE_DEFAULT',
                 next_step_idx=self.next_step_idx, 
@@ -66,21 +71,38 @@ class GI_OT_GenshinImportMaterials(Operator, ImportHelper, CustomOperatorPropert
             )
             return {'FINISHED'}
 
-        blend_file_with_genshin_materials = self.filepath or DEFAULT_BLEND_FILE_WITH_GENSHIN_MATERIALS
-        directory_with_blend_file_path = os.path.join(
+        blend_file_with_genshin_materials = os.path.join(
+            user_selected_shader_blend_file_path,
+            MATERIAL_PATH_INSIDE_BLEND_FILE
+        ) if user_selected_shader_blend_file_path else None
+
+        default_blend_file_path = os.path.join(
             project_root_directory_file_path,
-            blend_file_with_genshin_materials,
+            DEFAULT_BLEND_FILE_WITH_GENSHIN_MATERIALS,
             MATERIAL_PATH_INSIDE_BLEND_FILE
         )
 
-        bpy.ops.wm.append(
-            directory=directory_with_blend_file_path,
-            files=NAMES_OF_GENSHIN_MATERIALS
-        )
+        try:
+            # Use the exact file the user selected, otherwise fallback to the non-Goo blender file in the directory
+            shader_blend_file_path = blend_file_with_genshin_materials or default_blend_file_path
+            bpy.ops.wm.append(
+                directory=shader_blend_file_path,
+                files=NAMES_OF_GENSHIN_MATERIALS
+            )
+        except RuntimeError as ex:
+            super().clear_custom_properties()
+            self.report({'ERROR'}, \
+                f"ERROR: Error when trying to append materials. \n\
+                Did not find `{DEFAULT_BLEND_FILE_WITH_GENSHIN_MATERIALS}` in the directory you selected. \n\
+                Try selecting the exact blend file you want to use.")
+            raise ex
 
         self.report({'INFO'}, 'Imported Shader/Genshin Materials...')
-        if cache_enabled and project_root_directory_file_path:
-            cache_using_cache_key(get_cache(cache_enabled), FESTIVITY_ROOT_FOLDER_FILE_PATH, project_root_directory_file_path)
+        if cache_enabled and (user_selected_shader_blend_file_path or project_root_directory_file_path):
+            if user_selected_shader_blend_file_path:
+                cache_using_cache_key(get_cache(cache_enabled), FESTIVITY_SHADER_FILE_PATH, user_selected_shader_blend_file_path)
+            else:
+                cache_using_cache_key(get_cache(cache_enabled), FESTIVITY_ROOT_FOLDER_FILE_PATH, project_root_directory_file_path)
 
         NextStepInvoker().invoke(
             self.next_step_idx, 

--- a/setup_wizard/genshin_import_materials.py
+++ b/setup_wizard/genshin_import_materials.py
@@ -12,7 +12,7 @@ import os
 from setup_wizard.import_order import FESTIVITY_ROOT_FOLDER_FILE_PATH, NextStepInvoker, cache_using_cache_key, get_cache
 from setup_wizard.models import BasicSetupUIOperator, CustomOperatorProperties
 
-BLEND_FILE_WITH_GENSHIN_MATERIALS = 'miHoYo - Genshin Impact.blend'
+DEFAULT_BLEND_FILE_WITH_GENSHIN_MATERIALS = 'miHoYo - Genshin Impact.blend'
 MATERIAL_PATH_INSIDE_BLEND_FILE = 'Material'
 
 NAMES_OF_GENSHIN_MATERIALS = [
@@ -66,9 +66,10 @@ class GI_OT_GenshinImportMaterials(Operator, ImportHelper, CustomOperatorPropert
             )
             return {'FINISHED'}
 
+        blend_file_with_genshin_materials = self.filepath or DEFAULT_BLEND_FILE_WITH_GENSHIN_MATERIALS
         directory_with_blend_file_path = os.path.join(
             project_root_directory_file_path,
-            BLEND_FILE_WITH_GENSHIN_MATERIALS,
+            blend_file_with_genshin_materials,
             MATERIAL_PATH_INSIDE_BLEND_FILE
         )
 

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -86,16 +86,14 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
 
         lightmap_filename = [file for file in lightmap_files if actual_material_part_name in file][0]
         lightmap_node = outline_material.node_tree.nodes.get(v2_lightmap_node_name) \
-            if outline_material.node_tree.nodes.get(v2_lightmap_node_name) \
-                else outline_material.node_tree.nodes.get(v1_lightmap_node_name)
+            or outline_material.node_tree.nodes.get(v1_lightmap_node_name)
         self.assign_texture_to_node(lightmap_node, character_model_folder_file_path, lightmap_filename)
 
     def assign_diffuse_texture(self, character_model_folder_file_path, diffuse_files, body_part_material_name, actual_material_part_name):
         difuse_node_name = 'Outline_Diffuse'
         outline_material = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines')
         diffuse_node = outline_material.node_tree.nodes.get(difuse_node_name) \
-            if outline_material.node_tree.nodes.get(difuse_node_name) \
-                else None  # None for backwards compatibility in v1 where it did not exist
+            or None  # None for backwards compatibility in v1 where it did not exist
 
         if diffuse_node:
             diffuse_filename = [file for file in diffuse_files if actual_material_part_name in file][0]

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -64,7 +64,7 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
                 if 'Face' not in actual_material_part_name and 'Face' not in body_part_material_name:
                     self.assign_lightmap_texture(character_model_folder_file_path, lightmap_files, body_part_material_name, actual_material_part_name)
                     self.assign_diffuse_texture(character_model_folder_file_path, diffuse_files, body_part_material_name, actual_material_part_name)
-                    self.report({'INFO'}, f'Imported outline textures (diffuse and lightmap) onto material "{outline_material.name}"')
+                    self.report({'INFO'}, f'Imported outline texture(s) onto material "{outline_material.name}"')
             break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files
 
         if cache_enabled and character_model_folder_file_path:

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -64,7 +64,6 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
                 if 'Face' not in actual_material_part_name and 'Face' not in body_part_material_name:
                     self.assign_lightmap_texture(character_model_folder_file_path, lightmap_files, body_part_material_name, actual_material_part_name)
                     self.assign_diffuse_texture(character_model_folder_file_path, diffuse_files, body_part_material_name, actual_material_part_name)
-                    self.report({'INFO'}, f'Imported outline texture(s) onto material "{outline_material.name}"')
             break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files
 
         if cache_enabled and character_model_folder_file_path:
@@ -88,6 +87,7 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
         lightmap_node = outline_material.node_tree.nodes.get(v2_lightmap_node_name) \
             or outline_material.node_tree.nodes.get(v1_lightmap_node_name)
         self.assign_texture_to_node(lightmap_node, character_model_folder_file_path, lightmap_filename)
+        self.report({'INFO'}, f'Imported "{actual_material_part_name}" lightmap onto material "{outline_material.name}"')
 
     def assign_diffuse_texture(self, character_model_folder_file_path, diffuse_files, body_part_material_name, actual_material_part_name):
         difuse_node_name = 'Outline_Diffuse'
@@ -98,6 +98,7 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
         if diffuse_node:
             diffuse_filename = [file for file in diffuse_files if actual_material_part_name in file][0]
             self.assign_texture_to_node(diffuse_node, character_model_folder_file_path, diffuse_filename)
+            self.report({'INFO'}, f'Imported "{actual_material_part_name}" diffuse onto material "{outline_material.name}"')
 
     def assign_texture_to_node(self, node, character_model_folder_file_path, texture_file_name):
         texture_img_path = character_model_folder_file_path + "/" + texture_file_name

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -14,6 +14,7 @@ UI_ORDER_CONFIG_KEY = 'ui_order'
 
 # Cache Constants
 FESTIVITY_ROOT_FOLDER_FILE_PATH = 'festivity_root_folder_file_path'
+FESTIVITY_SHADER_FILE_PATH = "festivity_shader_file_path"
 FESTIVITY_OUTLINES_FILE_PATH = 'festivity_outlines_file_path'
 CHARACTER_MODEL_FOLDER_FILE_PATH = 'character_model_folder_file_path'
 

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -182,5 +182,7 @@ class ComponentFunctionFactory:
             return bpy.ops.genshin.set_color_management_to_standard
         elif component_name == 'setup_head_driver':
             return bpy.ops.genshin.setup_head_driver
+        elif component_name == 'clear_cache_operator':
+            return bpy.ops.genshin.clear_cache_operator
         else:
             raise Exception(f'Unknown component name passed into {__name__}: {component_name}')

--- a/setup_wizard/material_data_applier.py
+++ b/setup_wizard/material_data_applier.py
@@ -14,9 +14,10 @@ class MaterialDataApplier(ABC):
         '_OutlineColor5': 'Outline Color 5'
     }
 
-    def __init__(self, material_data_parser, body_part):
+    def __init__(self, material_data_parser, body_part, outlines_node_tree_node_name):
         self.material_data_parser = material_data_parser
         self.body_part = body_part
+        self.outlines_node_tree_node_name = outlines_node_tree_node_name
     
     @abstractmethod
     def set_up_mesh_material_data(self):
@@ -87,7 +88,7 @@ class V1_MaterialDataApplier(MaterialDataApplier):
     outlines_node_tree_node_name = 'Group.002'
 
     def __init__(self, material_data_parser, body_part):
-        super().__init__(material_data_parser, body_part)
+        super().__init__(material_data_parser, body_part, self.outlines_node_tree_node_name)
 
     def set_up_mesh_material_data(self):
         if self.body_part != 'Face':
@@ -160,7 +161,7 @@ class V2_MaterialDataApplier(MaterialDataApplier):
     outlines_node_tree_node_name = 'Group.006'
 
     def __init__(self, material_data_parser, body_part):
-        super().__init__(material_data_parser, body_part)
+        super().__init__(material_data_parser, body_part, self.outlines_node_tree_node_name)
 
     def set_up_mesh_material_data(self):
         body_part_material = bpy.data.materials[f'miHoYo - Genshin {self.body_part}']

--- a/setup_wizard/material_data_applier.py
+++ b/setup_wizard/material_data_applier.py
@@ -93,11 +93,11 @@ class V1_MaterialDataApplier(MaterialDataApplier):
     def set_up_mesh_material_data(self):
         if self.body_part != 'Face':
             body_part_material = bpy.data.materials[f'miHoYo - Genshin {self.body_part}']
-            node_tree_group001_inputs = body_part_material.node_tree.nodes[self.shader_node_tree_node_name].inputs
+            shader_node_tree_inputs = body_part_material.node_tree.nodes[self.shader_node_tree_node_name].inputs
 
             super().apply_material_data(
                 self.local_material_mapping,
-                node_tree_group001_inputs,
+                shader_node_tree_inputs,
             )
             
         # Not sure, should we only apply Global Material Properties from Body .dat file?
@@ -165,9 +165,9 @@ class V2_MaterialDataApplier(MaterialDataApplier):
 
     def set_up_mesh_material_data(self):
         body_part_material = bpy.data.materials[f'miHoYo - Genshin {self.body_part}']
-        node_tree_group001_inputs = body_part_material.node_tree.nodes[self.shader_node_tree_node_name].inputs
+        shader_node_tree_inputs = body_part_material.node_tree.nodes[self.shader_node_tree_node_name].inputs
 
         super().apply_material_data(
             self.local_material_mapping,
-            node_tree_group001_inputs,
+            shader_node_tree_inputs,
         )

--- a/setup_wizard/tests/character_filename_to_material_data_mapper.py
+++ b/setup_wizard/tests/character_filename_to_material_data_mapper.py
@@ -3,19 +3,17 @@ import os
 from pathlib import PurePath
 
 
-config = json.load(open('setup_wizard/tests/config.json'))
-characters_folder_file_path = config.get('characters_folder_file_path')
-
-material_json_folder_file_path = config.get('material_json_folder_file_path')
-material_json_files = os.listdir(material_json_folder_file_path)
-
 def main():
-    character_material_dictionary = get_character_material_dictionary()
+    config = json.load(open('setup_wizard/tests/config.json')).get('environments')[0]
+    character_material_dictionary = get_character_material_dictionary(config)
     return character_material_dictionary
 
 
-def get_character_material_dictionary():
+def get_character_material_dictionary(config):
     character_material_dictionary = {}
+    characters_folder_file_path = config.get('characters_folder_file_path')
+    material_json_folder_file_path = config.get('material_json_folder_file_path')
+    material_json_files = os.listdir(material_json_folder_file_path)
 
     for character_folder in os.listdir(characters_folder_file_path):
         for root, dirs, files in os.walk(PurePath(characters_folder_file_path, character_folder)):

--- a/setup_wizard/tests/config.json.sample
+++ b/setup_wizard/tests/config.json.sample
@@ -1,6 +1,26 @@
 {
-    "blender_execution_file_path": "FILE_PATH_TO_blender.exe",
-    "festivity_root_folder_file_path": "FILE_PATH_TO_festivity_shaders_folder",
-    "characters_folder_file_path": "FILE_PATH_TO_characters-folder",
-    "material_json_folder_file_path": "FILE_PATH_TO_material_data_folder"
+    "environments": [
+        {
+            "metadata": {
+                "name": "name of environment - vanilla blender",
+                "description": "description of environment"
+            },
+            "blender_execution_file_path": "FILE_PATH_TO_blender.exe",
+            "festivity_shader_file_path": "FILE_PATH_TO_festivity_shaders_blend_file",
+            "festivity_outlines_file_path": FILE_PATH_TO_festivity_outlines_blend_file",
+            "characters_folder_file_path": "FILE_PATH_TO_characters_folder",
+            "material_json_folder_file_path": "FILE_PATH_TO_material_data_folder"
+        },
+        {
+            "metadata": {
+                "name": "name of environment - goo blender",
+                "description": "description of enviornment"
+            },
+            "blender_execution_file_path": "FILE_PATH_TO_goo_blender.exe",
+            "festivity_root_folder_file_path": "FILE_PATH_TO_festivity_shaders_folder",
+            "festivity_outlines_file_path": "FILE_PATH_TO_festivity_outlines_blend_file",
+            "characters_folder_file_path": "FILE_PATH_TO_characters_folder",
+            "material_json_folder_file_path": "FILE_PATH_TO_material_data_folder"
+        },
+    }
 }

--- a/setup_wizard/tests/constants.py
+++ b/setup_wizard/tests/constants.py
@@ -2,4 +2,6 @@
 BLENDER_EXECUTION_FILE_PATH = 'blender_execution_file_path'
 CHARACTERS_FOLDER_FILE_PATH = 'characters_folder_file_path'
 FESTIVITY_ROOT_FOLDER_FILE_PATH = 'festivity_root_folder_file_path'
+FESTIVITY_SHADER_FILE_PATH = 'festivity_shader_file_path'
+FESTIVITY_OUTLINES_FILE_PATH = 'festivity_outlines_file_path'
 MATERIAL_JSON_FOLDER_FILE_PATH = 'material_json_folder_file_path'

--- a/setup_wizard/tests/test_setup_character.py
+++ b/setup_wizard/tests/test_setup_character.py
@@ -4,7 +4,8 @@ import logging
 import os
 import sys
 from pathlib import PurePath
-from setup_wizard.tests.constants import FESTIVITY_ROOT_FOLDER_FILE_PATH, MATERIAL_JSON_FOLDER_FILE_PATH
+from setup_wizard.tests.constants import FESTIVITY_ROOT_FOLDER_FILE_PATH, MATERIAL_JSON_FOLDER_FILE_PATH, \
+    FESTIVITY_SHADER_FILE_PATH, FESTIVITY_OUTLINES_FILE_PATH
 from setup_wizard.tests.logger import Logger
 from setup_wizard.tests.character_filename_to_material_data_mapper import get_character_material_dictionary
 from setup_wizard.tests.models.test_operator_executioner import TestOperatorExecutioner
@@ -23,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 def setup_character(config, character_name, character_folder_file_path):
     logger.info(f'Starting test for {character_name}')
+    logger.info(f'{config.get("metadata")}')
     try:
         material_json_folder_file_path = str(
             PurePath(config.get(MATERIAL_JSON_FOLDER_FILE_PATH), 
@@ -31,7 +33,7 @@ def setup_character(config, character_name, character_folder_file_path):
         )
         material_json_files = os.listdir(os.path.dirname(material_json_folder_file_path))
 
-        character_name_in_material_data = get_character_material_dictionary().get(character_name)
+        character_name_in_material_data = get_character_material_dictionary(config).get(character_name)
         material_json_files = [
             { 'name': material_json_file } for material_json_file in material_json_files
             if f'_{character_name_in_material_data}_' in material_json_file and 
@@ -44,17 +46,16 @@ def setup_character(config, character_name, character_folder_file_path):
         ]
 
         operators = [
+            TestOperatorExecutioner('clear_cache_operator'),
             TestOperatorExecutioner('import_character_model', file_directory=character_folder_file_path),
             TestOperatorExecutioner('delete_empties'),
-            TestOperatorExecutioner('import_materials', file_directory=config.get(FESTIVITY_ROOT_FOLDER_FILE_PATH)),
+            TestOperatorExecutioner('import_materials', 
+                file_directory=config.get(FESTIVITY_ROOT_FOLDER_FILE_PATH) or '',
+                filepath=config.get(FESTIVITY_SHADER_FILE_PATH) or '',
+            ),
             TestOperatorExecutioner('replace_default_materials'),
             TestOperatorExecutioner('import_character_textures'),
-            TestOperatorExecutioner('import_outlines', filepath=str(
-                PurePath(
-                    config.get(FESTIVITY_ROOT_FOLDER_FILE_PATH), 
-                    'miHoYo - Outlines.blend'
-                )
-            )),
+            TestOperatorExecutioner('import_outlines', filepath=config.get(FESTIVITY_OUTLINES_FILE_PATH)),
             TestOperatorExecutioner('setup_geometry_nodes'),
             TestOperatorExecutioner('import_outline_lightmaps', file_directory=character_folder_file_path),
             TestOperatorExecutioner('import_material_data', files=material_json_files, config=config),
@@ -74,7 +75,7 @@ def setup_character(config, character_name, character_folder_file_path):
     except Exception as ex:
         logger.error(ex)
         logger.error(f'Failed test for {arg_character_name}')
-        pass  # Unexpected exception! Catch any exception and quit
+        raise ex  # If it errors out it will still quit blender
     bpy.ops.wm.quit_blender()
 
 


### PR DESCRIPTION
### Change Notes:
- Added ability to select a specific blend file for importing materials (select either Vanilla or Goo `.blend` file)
  - Updated tooltip to mention selecting the specific `.blend` file
  - You can still select Festivity's shader folder (backwards compatible/fallback check), but going forward I'd like to move people to selecting the exact `.blend` file they want to import materials from)
- Made tests be runnable with different configurations to provide confidence that new changes do not break existing workflows
  - Goo Blender, Vanilla Blender
  - Old Import Materials (select Festivity folder), New Import Materials (select `.blend` file)
  - V1 Festivity shader, V2 Festivity shader
- Refactoring, refactoring and more refactoring