### PR TITLE
feat: support for festivity shader rewrite

### DIFF
--- a/setup_wizard/__init__.py
+++ b/setup_wizard/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Genshin Setup Wizard",
     "author": "Mken",
-    "version": (1, 1, 1),
+    "version": (1, 1, 3),
     "blender": (2, 80, 0),
     "location": "3D View > Sidebar > Genshin Impact Setup Wizard",
     "description": "An addon to streamline the character model setup process when using Festivity's Shaders",

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -10,9 +10,10 @@ from bpy_extras.io_utils import ImportHelper
 from bpy.props import StringProperty, CollectionProperty
 from bpy.types import Operator, PropertyGroup
 import os
-from setup_wizard.exceptions import UnsupportedMaterialDataJsonFormatException
 
+from setup_wizard.exceptions import UnsupportedMaterialDataJsonFormatException
 from setup_wizard.import_order import NextStepInvoker
+from setup_wizard.material_data_applier import MaterialDataApplier, V1_MaterialDataApplier, V2_MaterialDataApplier
 from setup_wizard.models import CustomOperatorProperties
 from setup_wizard.parsers.material_data_json_parsers import HoyoStudioMaterialDataJsonParser, MaterialDataJsonParser, UABEMaterialDataJsonParser
 
@@ -40,104 +41,10 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
 
     files: CollectionProperty(type=PropertyGroup)
 
-    local_material_mapping = {
-        '_FaceBlushColor': 'Face Blush Color',
-        '_FaceBlushStrength': 'Face Blush Strength',
-        # '_FaceMapSoftness': 'Face Shadow Softness',  # material data values are either 0.001 or 1E-06
-        "_UseMaterial2": 'Use Material 2',
-        "_UseMaterial3": 'Use Material 3',
-        "_UseMaterial4": 'Use Material 4',
-        "_UseMaterial5": 'Use Material 5',
-        '_UseBumpMap': 'Use Normal Map',
-        '_ShadowRampWidth': 'Shadow Ramp Width',
-        "_ShadowTransitionRange": 'Shadow Transition Range',
-        "_ShadowTransitionRange2": 'Shadow Transition Range 2',
-        "_ShadowTransitionRange3": 'Shadow Transition Range 3',
-        "_ShadowTransitionRange4": 'Shadow Transition Range 4',
-        "_ShadowTransitionRange5": 'Shadow Transition Range 5',
-        "_ShadowTransitionSoftness": 'Shadow Transition Softness',
-        "_ShadowTransitionSoftness2": 'Shadow Transition Softness 2',
-        "_ShadowTransitionSoftness3": 'Shadow Transition Softness 3',
-        "_ShadowTransitionSoftness4": 'Shadow Transition Softness 4',
-        "_ShadowTransitionSoftness5": 'Shadow Transition Softness 5',
-        '_MTMapBrightness': 'Metallic Matcap Brightness',
-        '_MTMapTileScale': 'Metallic Matcap Tile Scale',
-        '_MTMapLightColor': 'Metallic Matcap Light Color',
-        '_MTMapDarkColor': 'Metallic Matcap Dark Color',
-        '_MTShadowMultiColor': 'Metallic Matcap Shadow Multiply Color',
-        '_Shininess': 'Shininess',
-        '_Shininess2': 'Shininess 2',
-        '_Shininess3': 'Shininess 3',
-        '_Shininess4': 'Shininess 4',
-        '_Shininess5': 'Shininess 5',
-        '_SpecMulti': 'Specular Multiplier',
-        '_SpecMulti2': 'Specular Multiplier 2',
-        '_SpecMulti3': 'Specular Multiplier 3',
-        '_SpecMulti4': 'Specular Multiplier 4',
-        '_SpecMulti5': 'Specular Multiplier 5',
-        '_SpecularColor': 'Specular Color',
-        '_MTShininess': 'Metallic Specular Shininess',
-        '_MTSpecularScale': 'Metallic Specular Scale',
-        '_MTSpecularAttenInShadow': 'Metallic Specular Attenuation',
-        '_MTSharpLayerOffset': 'Metallic Specular Sharp Layer Offset',
-        '_MTSpecularColor': 'MT Specular Color',
-        '_MTSharpLayerColor': 'MT Sharp Layer Color',
-        '_MTUseSpecularRamp': 'Use Specular Ramp',
-    }
-
-    old_local_material_mapping = {
-        '_SpecMulti': 'Non-Metallic Specular Multiplier 1',
-        '_SpecMulti2': 'Non-Metallic Specular Multiplier 2',
-        '_SpecMulti3': 'Non-Metallic Specular Multiplier 3',
-        '_SpecMulti4': 'Non-Metallic Specular Multiplier 4',
-        '_SpecMulti5': 'Non-Metallic Specular Multiplier 5',
-        '_Shininess': 'Non-Metallic Specular Shininess 1',
-        '_Shininess2': 'Non-Metallic Specular Shininess 2',
-        '_Shininess3': 'Non-Metallic Specular Shininess 3',
-        '_Shininess4': 'Non-Metallic Specular Shininess 4',
-        '_Shininess5': 'Non-Metallic Specular Shininess 5',
-        '_MTMapLightColor': 'Metallic Light Color',
-        '_MTMapDarkColor': 'Metallic Dark Color',
-        '_MTShadowMultiColor': 'Metallic Shadow Multiply Color',
-        '_MTMapTileScale': 'Metallic Map Tile Scale',
-        '_MTMapBrightness': 'Metallic Brightness',
-        '_MTSpecularColor': 'Metallic Specular Color',
-        '_MTSpecularScale': 'Metallic Specular Scale',
-        '_MTShininess': 'Metallic Specular Shininess',
-        '_ShadowRampWidth': 'Ramp Width *NdotL only* *Ramp only*'
-    }
-
-    outline_mapping = {
-        '_OutlineColor': 'Outline Color 1',
-        '_OutlineColor2': 'Outline Color 2',
-        '_OutlineColor3': 'Outline Color 3',
-        '_OutlineColor4': 'Outline Color 4',
-        '_OutlineColor5': 'Outline Color 5'
-    }
-
-    old_global_material_mapping = {
-        '_MTUseSpecularRamp': 'Use Specular Ramp?',
-        '_FaceBlushColor': 'Blush Color',
-    }
-
-    global_material_mapping = {
-        '_MTUseSpecularRamp': 'Use Specular Ramp',
-        '_FaceBlushColor': 'Face Blush Color',
-    }
-
-    shader_node_tree_node_name = 'Group.006'
-    global_node_tree_node_name = 'Group.006'
-    outlines_node_tree_node_name = 'Group.006'
-    old_shader_node_tree_node_name = 'Group.001'
-    old_global_node_tree_node_name = 'Group Output'
-    old_outlines_node_tree_node_name = 'Group.002'
-
     parsers = [
         HoyoStudioMaterialDataJsonParser,
         UABEMaterialDataJsonParser,
     ]
-
-    material_data_appliers = []
 
     def execute(self, context):
         directory_file_path = os.path.dirname(self.filepath)
@@ -159,14 +66,18 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             json_material_data = json.load(fp)
             material_data_parser = self.__get_material_data_json_parser(json_material_data)
 
-            try:
-                self.set_up_mesh_material_data(material_data_parser, body_part)
-                self.set_up_outline_colors(material_data_parser, body_part)
-            except KeyError:
-                self.report({'WARNING'}, \
-                    f'Continuing to apply other material data, but: \n'
-                    f'* Material Data JSON "{body_part}" was selected, but there is no material named "miHoYo - Genshin {body_part}"')
-                continue
+            for material_data_applier_cls in [V2_MaterialDataApplier, V1_MaterialDataApplier]:
+                try:
+                    material_data_applier: MaterialDataApplier = material_data_applier_cls(material_data_parser, body_part)
+                    material_data_applier.set_up_mesh_material_data()
+                    material_data_applier.set_up_outline_colors()
+                except AttributeError:
+                    continue # fallback and try next version
+                except KeyError:
+                    self.report({'WARNING'}, \
+                        f'Continuing to apply other material data, but: \n'
+                        f'* Material Data JSON "{body_part}" was selected, but there is no material named "miHoYo - Genshin {body_part}"')
+                    break
 
         self.report({'INFO'}, 'Imported material data')
         NextStepInvoker().invoke(
@@ -177,43 +88,6 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
         super().clear_custom_properties()
         return {'FINISHED'}
 
-    def set_up_mesh_material_data(self, material_data_parser, body_part):
-        if body_part != 'Face':
-            body_part_material = bpy.data.materials[f'miHoYo - Genshin {body_part}']
-            node_tree_group001_inputs = body_part_material.node_tree.nodes[self.shader_node_tree_node_name].inputs
-
-            self.__apply_material_data(
-                self.local_material_mapping,
-                node_tree_group001_inputs,
-                material_data_parser,
-                body_part
-            )
-            
-        # Not sure, should we only apply Global Material Properties from Body .dat file?
-        if body_part == 'Body':
-            # TODO: Add backwards compatibility
-            return  # SpecularRamp/FaceBlush already covered
-            global_material_properties_node_inputs = \
-                bpy.data.node_groups["GLOBAL MATERIAL PROPERTIES"].nodes["Group Output"].inputs
-
-            self.__apply_material_data(
-                self.global_material_mapping,
-                global_material_properties_node_inputs,
-                material_data_parser,
-                body_part
-            )
-
-    def set_up_outline_colors(self, material_data_parser, body_part):
-        outlines_material = bpy.data.materials[f'miHoYo - Genshin {body_part} Outlines']
-        outlines_shader_node_inputs = outlines_material.node_tree.nodes.get(self.outlines_node_tree_node_name).inputs
-
-        self.__apply_material_data(
-            self.outline_mapping, 
-            outlines_shader_node_inputs,
-            material_data_parser,
-            body_part
-        )
-
     def __get_material_data_json_parser(self, json_material_data):
         for index, parser_class in enumerate(self.parsers):
             try:
@@ -223,26 +97,6 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             except AttributeError:
                 if index == len(self.parsers) - 1:
                     raise UnsupportedMaterialDataJsonFormatException(self.parsers)
-
-    def __apply_material_data(self, material_mapping, node_inputs, material_data_parser, body_part):
-        for material_json_name, material_node_name in material_mapping.items():
-            material_json_value = self.__get_value_in_json_parser(material_data_parser, material_json_name)
-
-            if not material_json_value:
-                self.__handle_material_value_not_found(body_part, material_json_name)
-                continue
-
-            node_input = node_inputs.get(material_node_name)
-            # print(f'Debug: Material Node Name: {material_node_name}')
-            node_input.default_value = material_json_value
-
-    def __get_value_in_json_parser(self, parser, key):
-        return getattr(parser.m_floats, key, None) or getattr(parser.m_colors, key, None)
-
-    def __handle_material_value_not_found(self, body_part, material_json_name):
-        # Log at INFO level because otherwise it may become "just another warning" and get ignored
-        self.report({'INFO'}, f'Unable to find material data: {material_json_name} on {body_part} JSON. \n' \
-            '* This may or may not be expected. Continuing to apply other material data.')
 
 
 register, unregister = bpy.utils.register_classes_factory(GI_OT_GenshinImportMaterialData)

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -67,7 +67,16 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
                     img.alpha_mode = 'CHANNEL_PACKED'
 
                     self.report({'INFO'}, f'Importing lightmap texture "{file}" onto material "{outline_material.name}"')
-                    bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get('Image Texture').image = img
+
+                    # TODO: Refactor. Also, we need to assign Diffuse
+                    old_lightmap_node_name = 'Image Texture'
+                    rewrite_lightmap_node_name = 'Outline_Lightmap'
+
+                    lightmap_node = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(old_lightmap_node_name) \
+                        if bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(old_lightmap_node_name) \
+                            else bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(rewrite_lightmap_node_name)
+
+                    lightmap_node.image = img
             break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files
 
         if cache_enabled and character_model_folder_file_path:

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -59,6 +59,7 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
                 body_part_material_name = outline_material.name.split(' ')[-2]  # ex. 'miHoYo - Genshin Hair Outlines'
                 original_material_name = [material for material in bpy.data.materials if material.name.endswith(f'Mat_{body_part_material_name}')][0]  # from original model
                 material_part_name = get_actual_material_name_for_dress(original_material_name.name)
+
                 if 'Face' not in material_part_name and 'Face' not in body_part_material_name:
                     file = [file for file in lightmap_files if material_part_name in file][0]
 
@@ -75,8 +76,20 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
                     lightmap_node = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(old_lightmap_node_name) \
                         if bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(old_lightmap_node_name) \
                             else bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(rewrite_lightmap_node_name)
-
                     lightmap_node.image = img
+
+                    rewrite_difuse_node_name = 'Outline_Diffuse'
+                    diffuse_node = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(rewrite_difuse_node_name) \
+                        if bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(rewrite_difuse_node_name) \
+                            else None
+                    if diffuse_node:
+                        print(body_part_material_name)
+                        # TODO: Refactor this logic as it's common with the Lightmap img
+                        diffuse_file = [file for file in files if 'Diffuse' in file and f'{material_part_name}' in file][0]
+                        diffuse_img_path = character_model_folder_file_path + "/" + diffuse_file
+                        diffuse_img = bpy.data.images.load(filepath = diffuse_img_path, check_existing=True)
+                        diffuse_img.alpha_mode = 'CHANNEL_PACKED'
+                        diffuse_node.image = diffuse_img
             break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files
 
         if cache_enabled and character_model_folder_file_path:

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -82,17 +82,19 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
     def assign_lightmap_texture(self, character_model_folder_file_path, lightmap_files, body_part_material_name, actual_material_part_name):
         v1_lightmap_node_name = 'Image Texture'
         v2_lightmap_node_name = 'Outline_Lightmap'
+        outline_material = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines')
 
         lightmap_filename = [file for file in lightmap_files if actual_material_part_name in file][0]
-        lightmap_node = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(v2_lightmap_node_name) \
-            if bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(v2_lightmap_node_name) \
-                else bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(v1_lightmap_node_name)
+        lightmap_node = outline_material.node_tree.nodes.get(v2_lightmap_node_name) \
+            if outline_material.node_tree.nodes.get(v2_lightmap_node_name) \
+                else outline_material.node_tree.nodes.get(v1_lightmap_node_name)
         self.assign_texture_to_node(lightmap_node, character_model_folder_file_path, lightmap_filename)
 
     def assign_diffuse_texture(self, character_model_folder_file_path, diffuse_files, body_part_material_name, actual_material_part_name):
         difuse_node_name = 'Outline_Diffuse'
-        diffuse_node = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(difuse_node_name) \
-            if bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines').node_tree.nodes.get(difuse_node_name) \
+        outline_material = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines')
+        diffuse_node = outline_material.node_tree.nodes.get(difuse_node_name) \
+            if outline_material.node_tree.nodes.get(difuse_node_name) \
                 else None  # None for backwards compatibility in v1 where it did not exist
 
         if diffuse_node:

--- a/setup_wizard/genshin_import_textures.py
+++ b/setup_wizard/genshin_import_textures.py
@@ -130,19 +130,26 @@ class GI_OT_GenshinImportTextures(Operator, ImportHelper, CustomOperatorProperti
         super().clear_custom_properties()
         return {'FINISHED'}
 
+    '''
+    Deprecated: No longer needed after shader rewrite because normal map is plugged by default
+    Still maintains backward compatibility by only trying this if `label_name` is found in the node tree.
+    '''
     def plug_normal_map(self, shader_material_name, label_name):
         shader_group_material_name = 'Group.001'
         shader_material = bpy.data.materials.get(shader_material_name)
 
         if shader_material:
-            normal_map_node_color_output = [node.outputs.get('Color') for node in shader_material.node_tree.nodes \
-                if node.label == label_name and not node.outputs.get('Color').is_linked][0]
-            normal_map_input = shader_material.node_tree.nodes.get(shader_group_material_name).inputs.get('Normal Map')
+            normal_map_node_color_outputs = [node.outputs.get('Color') for node in shader_material.node_tree.nodes \
+                if node.label == label_name and not node.outputs.get('Color').is_linked]
+            
+            if normal_map_node_color_outputs:
+                normal_map_node_color_output = normal_map_node_color_outputs[0]
+                normal_map_input = shader_material.node_tree.nodes.get(shader_group_material_name).inputs.get('Normal Map')
 
-            bpy.data.materials.get(shader_material_name).node_tree.links.new(
-                normal_map_node_color_output,
-                normal_map_input
-            )
+                bpy.data.materials.get(shader_material_name).node_tree.links.new(
+                    normal_map_node_color_output,
+                    normal_map_input
+                )
     
     def setup_dress_textures(self, texture_name, texture_img):
         shader_dress_materials = [material for material in bpy.data.materials if 'Genshin Dress' in material.name]

--- a/setup_wizard/genshin_setup_wizard.py
+++ b/setup_wizard/genshin_setup_wizard.py
@@ -6,7 +6,6 @@ from bpy.types import Operator
 from setup_wizard.import_order import NextStepInvoker
 
 from setup_wizard.models import BasicSetupUIOperator
-from setup_wizard.ui_setup_wizard_menu import version_number_above_or_equal
 
 
 class GI_OT_GenshinSetupWizardUI(Operator, BasicSetupUIOperator):
@@ -20,7 +19,7 @@ class GI_OT_GenshinSetupWizardUI(Operator, BasicSetupUIOperator):
         NextStepInvoker().invoke(
             next_step_index,
             'invoke_next_step_ui', 
-            high_level_step_name=self.bl_idname if version_number_above_or_equal((3, 3, 0)) \
+            high_level_step_name=self.bl_idname if bpy.app.version >= (3,3,0) >= (3,3,0) \
                 else self.bl_idname + '_no_outlines'
         )
         return {'FINISHED'}

--- a/setup_wizard/material_data_applier.py
+++ b/setup_wizard/material_data_applier.py
@@ -1,0 +1,172 @@
+# Author: michael-gh1
+
+import bpy
+
+from abc import ABC, abstractmethod
+
+
+class MaterialDataApplier(ABC):
+    outline_mapping = {
+        '_OutlineColor': 'Outline Color 1',
+        '_OutlineColor2': 'Outline Color 2',
+        '_OutlineColor3': 'Outline Color 3',
+        '_OutlineColor4': 'Outline Color 4',
+        '_OutlineColor5': 'Outline Color 5'
+    }
+
+    def __init__(self, material_data_parser, body_part):
+        self.material_data_parser = material_data_parser
+        self.body_part = body_part
+    
+    @abstractmethod
+    def set_up_mesh_material_data(self):
+        raise NotImplementedError()
+
+    def set_up_outline_colors(self):
+        outlines_material = bpy.data.materials[f'miHoYo - Genshin {self.body_part} Outlines']
+        outlines_shader_node_inputs = outlines_material.node_tree.nodes.get(self.outlines_node_tree_node_name).inputs
+
+        self.apply_material_data(
+            self.outline_mapping, 
+            outlines_shader_node_inputs,
+        )
+
+    def apply_material_data(self, material_mapping, node_inputs):
+        for material_json_name, material_node_name in material_mapping.items():
+            material_json_value = self.__get_value_in_json_parser(self.material_data_parser, material_json_name)
+
+            if material_json_value is None:  # explicitly check for None
+                self.__handle_material_value_not_found(material_json_name)
+                continue
+
+            node_input = node_inputs.get(material_node_name)
+            node_input.default_value = material_json_value
+
+    def __get_value_in_json_parser(self, parser, key):
+        try:
+            return getattr(parser.m_floats, key)
+        except AttributeError:
+            return getattr(parser.m_colors, key, None)
+        except Exception:
+            return None
+
+    def __handle_material_value_not_found(self, material_json_name):
+        print(f'Info: Unable to find material data: {material_json_name} on {self.body_part} JSON.')
+
+
+class V1_MaterialDataApplier(MaterialDataApplier):
+    local_material_mapping = {
+        '_SpecMulti': 'Non-Metallic Specular Multiplier 1',
+        '_SpecMulti2': 'Non-Metallic Specular Multiplier 2',
+        '_SpecMulti3': 'Non-Metallic Specular Multiplier 3',
+        '_SpecMulti4': 'Non-Metallic Specular Multiplier 4',
+        '_SpecMulti5': 'Non-Metallic Specular Multiplier 5',
+        '_Shininess': 'Non-Metallic Specular Shininess 1',
+        '_Shininess2': 'Non-Metallic Specular Shininess 2',
+        '_Shininess3': 'Non-Metallic Specular Shininess 3',
+        '_Shininess4': 'Non-Metallic Specular Shininess 4',
+        '_Shininess5': 'Non-Metallic Specular Shininess 5',
+        '_MTMapLightColor': 'Metallic Light Color',
+        '_MTMapDarkColor': 'Metallic Dark Color',
+        '_MTShadowMultiColor': 'Metallic Shadow Multiply Color',
+        '_MTMapTileScale': 'Metallic Map Tile Scale',
+        '_MTMapBrightness': 'Metallic Brightness',
+        '_MTSpecularColor': 'Metallic Specular Color',
+        '_MTSpecularScale': 'Metallic Specular Scale',
+        '_MTShininess': 'Metallic Specular Shininess',
+        '_ShadowRampWidth': 'Ramp Width *NdotL only* *Ramp only*'
+    }
+
+    global_material_mapping = {
+        '_MTUseSpecularRamp': 'Use Specular Ramp?',
+        '_FaceBlushColor': 'Blush Color',
+    }
+
+    shader_node_tree_node_name = 'Group.001'
+    global_node_group_node_name = 'Group Output'
+    outlines_node_tree_node_name = 'Group.002'
+
+    def __init__(self, material_data_parser, body_part):
+        super().__init__(material_data_parser, body_part)
+
+    def set_up_mesh_material_data(self):
+        if self.body_part != 'Face':
+            body_part_material = bpy.data.materials[f'miHoYo - Genshin {self.body_part}']
+            node_tree_group001_inputs = body_part_material.node_tree.nodes[self.shader_node_tree_node_name].inputs
+
+            super().apply_material_data(
+                self.local_material_mapping,
+                node_tree_group001_inputs,
+            )
+            
+        # Not sure, should we only apply Global Material Properties from Body .dat file?
+        if self.body_part == 'Body':
+            global_material_properties_node_inputs = \
+                bpy.data.node_groups["GLOBAL MATERIAL PROPERTIES"].nodes[self.global_node_group_node_name].inputs
+
+            super().apply_material_data(
+                self.global_material_mapping,
+                global_material_properties_node_inputs,
+            )
+
+
+class V2_MaterialDataApplier(MaterialDataApplier):
+    local_material_mapping = {
+        '_FaceBlushColor': 'Face Blush Color',
+        '_FaceBlushStrength': 'Face Blush Strength',
+        # '_FaceMapSoftness': 'Face Shadow Softness',  # material data values are either 0.001 or 1E-06
+        "_UseMaterial2": 'Use Material 2',
+        "_UseMaterial3": 'Use Material 3',
+        "_UseMaterial4": 'Use Material 4',
+        "_UseMaterial5": 'Use Material 5',
+        '_UseBumpMap': 'Use Normal Map',
+        '_ShadowRampWidth': 'Shadow Ramp Width',
+        "_ShadowTransitionRange": 'Shadow Transition Range',
+        "_ShadowTransitionRange2": 'Shadow Transition Range 2',
+        "_ShadowTransitionRange3": 'Shadow Transition Range 3',
+        "_ShadowTransitionRange4": 'Shadow Transition Range 4',
+        "_ShadowTransitionRange5": 'Shadow Transition Range 5',
+        "_ShadowTransitionSoftness": 'Shadow Transition Softness',
+        "_ShadowTransitionSoftness2": 'Shadow Transition Softness 2',
+        "_ShadowTransitionSoftness3": 'Shadow Transition Softness 3',
+        "_ShadowTransitionSoftness4": 'Shadow Transition Softness 4',
+        "_ShadowTransitionSoftness5": 'Shadow Transition Softness 5',
+        '_MTMapBrightness': 'Metallic Matcap Brightness',
+        '_MTMapTileScale': 'Metallic Matcap Tile Scale',
+        '_MTMapLightColor': 'Metallic Matcap Light Color',
+        '_MTMapDarkColor': 'Metallic Matcap Dark Color',
+        '_MTShadowMultiColor': 'Metallic Matcap Shadow Multiply Color',
+        '_Shininess': 'Shininess',
+        '_Shininess2': 'Shininess 2',
+        '_Shininess3': 'Shininess 3',
+        '_Shininess4': 'Shininess 4',
+        '_Shininess5': 'Shininess 5',
+        '_SpecMulti': 'Specular Multiplier',
+        '_SpecMulti2': 'Specular Multiplier 2',
+        '_SpecMulti3': 'Specular Multiplier 3',
+        '_SpecMulti4': 'Specular Multiplier 4',
+        '_SpecMulti5': 'Specular Multiplier 5',
+        '_SpecularColor': 'Specular Color',
+        '_MTShininess': 'Metallic Specular Shininess',
+        '_MTSpecularScale': 'Metallic Specular Scale',
+        '_MTSpecularAttenInShadow': 'Metallic Specular Attenuation',
+        '_MTSharpLayerOffset': 'Metallic Specular Sharp Layer Offset',
+        '_MTSpecularColor': 'MT Specular Color',
+        '_MTSharpLayerColor': 'MT Sharp Layer Color',
+        '_MTUseSpecularRamp': 'Use Specular Ramp',
+    }
+
+    shader_node_tree_node_name = 'Group.006'
+    outlines_node_tree_node_name = 'Group.006'
+
+    def __init__(self, material_data_parser, body_part):
+        super().__init__(material_data_parser, body_part)
+
+    def set_up_mesh_material_data(self):
+        body_part_material = bpy.data.materials[f'miHoYo - Genshin {self.body_part}']
+        node_tree_group001_inputs = body_part_material.node_tree.nodes[self.shader_node_tree_node_name].inputs
+
+        super().apply_material_data(
+            self.local_material_mapping,
+            node_tree_group001_inputs,
+        )

--- a/setup_wizard/ui_setup_wizard_menu.py
+++ b/setup_wizard/ui_setup_wizard_menu.py
@@ -63,7 +63,7 @@ class GI_PT_Basic_Setup_Wizard_UI_Layout(Panel):
             'Set Up Materials',
             icon='MATERIAL'
         )
-        if version_number_above_or_equal((3, 3, 0)):
+        if bpy.app.version >= (3,3,0):
             OperatorFactory.create(
                 sub_layout,
                 'genshin.set_up_outlines',
@@ -159,7 +159,7 @@ class GI_PT_UI_Outlines_Menu(Panel):
         layout = self.layout
         sub_layout = layout.column()
 
-        if version_number_above_or_equal((3, 3, 0)):
+        if bpy.app.version >= (3,3,0):
             OperatorFactory.create(
                 sub_layout,
                 'genshin.import_outlines',
@@ -223,17 +223,6 @@ class GI_PT_UI_Finish_Setup_Menu(Panel):
             'Delete EffectMesh',
             'TRASH'
         )
-
-
-def version_number_above_or_equal(required_version_number_tuple):
-    current_version = bpy.app.version
-
-    for index in range(0, len(required_version_number_tuple)):
-        if current_version[index] < required_version_number_tuple[index]:
-            return False
-        elif current_version[index] > required_version_number_tuple[index]:
-            return True
-    return True
 
 
 '''


### PR DESCRIPTION
Support for Festivity's shader rewrite with backwards compatibility.

### Support for Festivity's Shader Rewrite
- No longer need to plug normal map
- Outline lightmap node was renamed
- A new node for diffuse texture be assigned for Outlines
- Material data - tons of new values and some old ones were renamed or removed