### PR TITLE
feat: set default _MTSharpLayerOffset value when it does not exist in material data

### DIFF
--- a/setup_wizard/parsers/data_classes.py
+++ b/setup_wizard/parsers/data_classes.py
@@ -4,6 +4,13 @@
     Data class that is used to store values from m_Floats and m_Colors from Material Data Jsons
 '''
 class MaterialData:
+    default_values = {
+        '_MTSharpLayerOffset': 1.0
+    }
+
     def __init__(self, json_m_data):
+        for default_key, default_value in self.default_values.items():
+            setattr(self, default_key, default_value)
+
         for key, value in json_m_data.items():
             setattr(self, key, value)


### PR DESCRIPTION
* As requested, set `_MTSharpLayerOffset` to `1.0` when it does not exist in the material data JSON file
  * I think this disables it in the shader?