### PR TITLE
feat: implement (experimental) betterfbx support

### DIFF
--- a/setup_wizard/tests/config.json.sample
+++ b/setup_wizard/tests/config.json.sample
@@ -3,7 +3,8 @@
         {
             "metadata": {
                 "name": "name of environment - vanilla blender",
-                "description": "description of environment"
+                "description": "description of environment",
+                "enabled": true
             },
             "blender_execution_file_path": "FILE_PATH_TO_blender.exe",
             "festivity_shader_file_path": "FILE_PATH_TO_festivity_shaders_blend_file",
@@ -14,7 +15,8 @@
         {
             "metadata": {
                 "name": "name of environment - goo blender",
-                "description": "description of enviornment"
+                "description": "description of enviornment",
+                "enabled": true
             },
             "blender_execution_file_path": "FILE_PATH_TO_goo_blender.exe",
             "festivity_root_folder_file_path": "FILE_PATH_TO_festivity_shaders_folder",

--- a/setup_wizard/tests/test_driver.py
+++ b/setup_wizard/tests/test_driver.py
@@ -26,6 +26,9 @@ class TestDriver:
         environment_configs = self.config_service.get('environments')
 
         for environment_config in environment_configs:
+            if not environment_config.get('metadata').get('enabled'):
+                continue
+
             characters_folder_file_path = environment_config.get(CHARACTERS_FOLDER_FILE_PATH)  # root level
             character_folders = os.listdir(characters_folder_file_path)  # all folders inside
             environment_config_str = json.dumps(environment_config)

--- a/setup_wizard/ui_setup_wizard_menu.py
+++ b/setup_wizard/ui_setup_wizard_menu.py
@@ -11,6 +11,13 @@ class UI_Properties:
             default = True
         )
 
+        betterfbx_installed = bpy.context.preferences.addons.get('better_fbx')
+        if betterfbx_installed:
+            bpy.types.WindowManager.setup_wizard_betterfbx_enabled = bpy.props.BoolProperty(
+                name = "BetterFBX Enabled",
+                default = True
+            )
+
 
 class GI_PT_Setup_Wizard_UI_Layout(Panel):
     bl_label = "Genshin Impact Setup Wizard"
@@ -38,6 +45,11 @@ class GI_PT_Setup_Wizard_UI_Layout(Panel):
             'Clear Cache',
             'TRASH'
         )
+
+        betterfbx_installed = bpy.context.preferences.addons.get('better_fbx')
+        if betterfbx_installed:
+            row2 = layout.row()
+            row2.prop(window_manager, 'setup_wizard_betterfbx_enabled')
 
 
 class GI_PT_Basic_Setup_Wizard_UI_Layout(Panel):


### PR DESCRIPTION
* Added (experimental) BetterFBX support
  * When I say experimental, I mean that I don't know what exact parameters should be passed through to BetterFBX by default...
  * Currently using all default parameters and just passing in the `.fbx` file to import
* BetterFBX import is enabled by default if it's installed, but can be unchecked to turn it off to revert back to Blender's vanilla FBX import (has `force_connect_children` = `True` and `automatic_bone_orientation` = `True`)
* Also made tests configurable to enable/disable BetterFBX for testability