### PR TITLE
feat: apply Emission Tint using material data + material data bugfix

### DIFF
--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -71,6 +71,7 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
                     material_data_applier: MaterialDataApplier = material_data_applier_cls(material_data_parser, body_part)
                     material_data_applier.set_up_mesh_material_data()
                     material_data_applier.set_up_outline_colors()
+                    break  # Important! If a MaterialDataApplier runs successfully, we don't need to try the next version
                 except AttributeError:
                     continue # fallback and try next version
                 except KeyError:

--- a/setup_wizard/material_data_applier.py
+++ b/setup_wizard/material_data_applier.py
@@ -44,7 +44,7 @@ class MaterialDataApplier(ABC):
             try:
                 node_input.default_value = material_json_value
             except AttributeError as ex:
-                print(f'Did not find {material_node_name} in {self.body_part} material. \
+                print(f'Did not find {material_node_name} in {self.body_part} material using {self} \
                     Falling back to next MaterialDataApplier version')
                 raise ex
 
@@ -57,7 +57,7 @@ class MaterialDataApplier(ABC):
             return None
 
     def __handle_material_value_not_found(self, material_json_name):
-        print(f'Info: Unable to find material data: {material_json_name} on {self.body_part} JSON.')
+        print(f'Info: Unable to find material data: {material_json_name} in {self.body_part} JSON.')
 
 
 class V1_MaterialDataApplier(MaterialDataApplier):

--- a/setup_wizard/material_data_applier.py
+++ b/setup_wizard/material_data_applier.py
@@ -41,7 +41,12 @@ class MaterialDataApplier(ABC):
                 continue
 
             node_input = node_inputs.get(material_node_name)
-            node_input.default_value = material_json_value
+            try:
+                node_input.default_value = material_json_value
+            except AttributeError as ex:
+                print(f'Did not find {material_node_name} in {self.body_part} material. \
+                    Falling back to next MaterialDataApplier version')
+                raise ex
 
     def __get_value_in_json_parser(self, parser, key):
         try:

--- a/setup_wizard/material_data_applier.py
+++ b/setup_wizard/material_data_applier.py
@@ -116,6 +116,7 @@ class V2_MaterialDataApplier(MaterialDataApplier):
         '_FaceBlushColor': 'Face Blush Color',
         '_FaceBlushStrength': 'Face Blush Strength',
         # '_FaceMapSoftness': 'Face Shadow Softness',  # material data values are either 0.001 or 1E-06
+        "_EmissionColor_MHY": "Emission Tint",
         "_UseMaterial2": 'Use Material 2',
         "_UseMaterial3": 'Use Material 3',
         "_UseMaterial4": 'Use Material 4',


### PR DESCRIPTION
* Apply Emission Tint using material data
* Bugfix where all MaterialDataAppliers (V2 and V1) would try applying data, even if one of them (ex. V2) had already successfully applied material data
  * No impact on the end result (as it would just reapply the same value, but it could've lead to a future bug)