### PR TITLE
feat: support for applying weapon material data

### DIFF
--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -72,8 +72,10 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             # Was tempted to add another check, but holding off for now: file.name.startswith('Avatar')
             is_weapon = body_part == WEAPON_NAME_IDENTIFIER
 
+            # V2_WeaponMaterialDataApplier is technically unnecessary for now, does same logic as V2_MaterialDataApplier
             material_data_appliers = [
-                V2_WeaponMaterialDataApplier(material_data_parser, 'Body'),
+                V2_WeaponMaterialDataApplier(material_data_parser, 'Body'),  
+                V1_MaterialDataApplier(material_data_parser, 'Body'),
             ] if is_weapon else [
                 V2_MaterialDataApplier(material_data_parser, body_part), 
                 V1_MaterialDataApplier(material_data_parser, body_part),

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -13,7 +13,7 @@ import os
 
 from setup_wizard.exceptions import UnsupportedMaterialDataJsonFormatException
 from setup_wizard.import_order import NextStepInvoker
-from setup_wizard.material_data_applier import V1_MaterialDataApplier, V1_WeaponMaterialDataApplier, V2_MaterialDataApplier
+from setup_wizard.material_data_applier import V1_MaterialDataApplier, V2_WeaponMaterialDataApplier, V2_MaterialDataApplier
 from setup_wizard.models import CustomOperatorProperties
 from setup_wizard.parsers.material_data_json_parsers import HoyoStudioMaterialDataJsonParser, MaterialDataJsonParser, UABEMaterialDataJsonParser
 
@@ -73,7 +73,7 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             is_weapon = body_part == WEAPON_NAME_IDENTIFIER
 
             material_data_appliers = [
-                V1_WeaponMaterialDataApplier(material_data_parser, 'Body'),
+                V2_WeaponMaterialDataApplier(material_data_parser, 'Body'),
             ] if is_weapon else [
                 V2_MaterialDataApplier(material_data_parser, body_part), 
                 V1_MaterialDataApplier(material_data_parser, body_part),

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -69,17 +69,19 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
             json_material_data = json.load(fp)
             material_data_parser = self.__get_material_data_json_parser(json_material_data)
 
-            # Was tempted to add another check, but holding off for now: file.name.startswith('Avatar')
-            is_weapon = body_part == WEAPON_NAME_IDENTIFIER
-
             # V2_WeaponMaterialDataApplier is technically unnecessary for now, does same logic as V2_MaterialDataApplier
-            material_data_appliers = [
+            weapon_material_data_appliers = [
                 V2_WeaponMaterialDataApplier(material_data_parser, 'Body'),  
                 V1_MaterialDataApplier(material_data_parser, 'Body'),
-            ] if is_weapon else [
+            ]
+            character_model_material_data_appliers = [
                 V2_MaterialDataApplier(material_data_parser, body_part), 
                 V1_MaterialDataApplier(material_data_parser, body_part),
             ]
+            # Was tempted to add another check, but holding off for now: file.name.startswith('Equip')
+            is_weapon = body_part == WEAPON_NAME_IDENTIFIER
+
+            material_data_appliers = weapon_material_data_appliers if is_weapon else character_model_material_data_appliers
 
             for material_data_applier in material_data_appliers:
                 try:

--- a/setup_wizard/material_data_applier.py
+++ b/setup_wizard/material_data_applier.py
@@ -179,7 +179,7 @@ class V2_MaterialDataApplier(MaterialDataApplier):
         )
 
 
-class V1_WeaponMaterialDataApplier(V2_MaterialDataApplier):
+class V2_WeaponMaterialDataApplier(V2_MaterialDataApplier):
     def __init__(self, material_data_parser, body_part):
         super().__init__(material_data_parser, body_part)
 

--- a/setup_wizard/material_data_applier.py
+++ b/setup_wizard/material_data_applier.py
@@ -177,3 +177,17 @@ class V2_MaterialDataApplier(MaterialDataApplier):
             self.local_material_mapping,
             shader_node_tree_inputs,
         )
+
+
+class V1_WeaponMaterialDataApplier(V2_MaterialDataApplier):
+    def __init__(self, material_data_parser, body_part):
+        super().__init__(material_data_parser, body_part)
+
+    def set_up_mesh_material_data(self):
+        weapon_material = bpy.data.materials[f'miHoYo - Genshin {self.body_part}']
+        shader_node_tree_inputs = weapon_material.node_tree.nodes[self.shader_node_tree_node_name].inputs
+
+        super().apply_material_data(
+            self.local_material_mapping,
+            shader_node_tree_inputs,
+        )


### PR DESCRIPTION
- Added support for applying weapon material data
- Currently `V2_WeaponMaterialDataApplier` is the same as `V2_MaterialDataApplier`, I kept the design I initially thought of in case the material data applying deviates from each other down the road (unlikely, but possible)