### PR TITLE
fix: broken shader/outlines in Blender v3.4

### DIFF
--- a/setup_wizard/__init__.py
+++ b/setup_wizard/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Genshin Setup Wizard",
     "author": "Mken",
-    "version": (1, 1, 5),
+    "version": (1, 1, 7),
     "blender": (2, 80, 0),
     "location": "3D View > Sidebar > Genshin Impact Setup Wizard",
     "description": "An addon to streamline the character model setup process when using Festivity's Shaders",

--- a/setup_wizard/genshin_import_character_model.py
+++ b/setup_wizard/genshin_import_character_model.py
@@ -18,6 +18,9 @@ from setup_wizard.import_order import get_cache, CHARACTER_MODEL_FOLDER_FILE_PAT
 from setup_wizard.models import BasicSetupUIOperator, CustomOperatorProperties
 
 
+SHADER_COLOR_ATTRIBUTE_NAME = 'Col'
+
+
 class GI_OT_SetUpCharacter(Operator, BasicSetupUIOperator):
     '''Sets Up Character'''
     bl_idname = 'genshin.set_up_character'
@@ -64,7 +67,7 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
             bpy.context.preferences.view.language = 'en_US'
             self.import_character_model(character_model_folder_file_path)
             self.reset_pose_location_and_rotation()
-            self.rename_mesh_color_attribute_name('Col')  # Blender 3.4 changed default name to 'Attribute', revert it
+            self.rename_mesh_color_attribute_name(SHADER_COLOR_ATTRIBUTE_NAME)  # Blender 3.4 changed default name to 'Attribute', revert it
         finally:
             bpy.context.preferences.view.language = original_language
 
@@ -121,6 +124,10 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
         bpy.ops.pose.rot_clear()
         bpy.ops.object.mode_set(mode='OBJECT')
 
+    '''
+        NOTE: This will rename the Color Attributes for ALL meshes
+        Currently expecting character setup to be performed in a fresh (new) file
+    '''
     def rename_mesh_color_attribute_name(self, name):
         meshes = [mesh for mesh_name, mesh in bpy.data.meshes.items()]
 

--- a/setup_wizard/genshin_import_character_model.py
+++ b/setup_wizard/genshin_import_character_model.py
@@ -64,6 +64,7 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
             bpy.context.preferences.view.language = 'en_US'
             self.import_character_model(character_model_folder_file_path)
             self.reset_pose_location_and_rotation()
+            self.rename_mesh_color_attribute_name('Col')  # Blender 3.4 changed default name to 'Attribute', revert it
         finally:
             bpy.context.preferences.view.language = original_language
 
@@ -119,6 +120,13 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
         bpy.ops.pose.loc_clear()
         bpy.ops.pose.rot_clear()
         bpy.ops.object.mode_set(mode='OBJECT')
+
+    def rename_mesh_color_attribute_name(self, name):
+        meshes = [mesh for mesh_name, mesh in bpy.data.meshes.items()]
+
+        for mesh in meshes:
+            if mesh.color_attributes.active_color:
+                mesh.color_attributes.active_color.name = name
 
     def __find_fbx_file(self, directory):
         for root, folder, files in os.walk(directory):


### PR DESCRIPTION
### Description
Adds support for Blender v3.4 by addressing the following issues:
- Closes #27
- Closes #28

### Change Summary
- Renames all mesh `Color Attributes` to `Col`
- Reorders `Face` mesh's material slots (adds temporary material slot, swaps material slots, removes temporary material slot