### PR TITLE
feat: add fake user to all imported materials during setup

### DIFF
--- a/setup_wizard/genshin_import_materials.py
+++ b/setup_wizard/genshin_import_materials.py
@@ -12,6 +12,7 @@ import os
 from setup_wizard.import_order import NextStepInvoker, cache_using_cache_key, get_cache, \
     FESTIVITY_ROOT_FOLDER_FILE_PATH, FESTIVITY_SHADER_FILE_PATH
 from setup_wizard.models import BasicSetupUIOperator, CustomOperatorProperties
+from setup_wizard.utils import material_utils
 
 DEFAULT_BLEND_FILE_WITH_GENSHIN_MATERIALS = 'miHoYo - Genshin Impact.blend'
 MATERIAL_PATH_INSIDE_BLEND_FILE = 'Material'
@@ -103,6 +104,10 @@ class GI_OT_GenshinImportMaterials(Operator, ImportHelper, CustomOperatorPropert
                 cache_using_cache_key(get_cache(cache_enabled), FESTIVITY_SHADER_FILE_PATH, user_selected_shader_blend_file_path)
             else:
                 cache_using_cache_key(get_cache(cache_enabled), FESTIVITY_ROOT_FOLDER_FILE_PATH, project_root_directory_file_path)
+
+        # Add fake user to prevent unused materials from being cleaned up
+        genshin_materials = [bpy.data.materials.get(genshin_material_name.get('name')) for genshin_material_name in NAMES_OF_GENSHIN_MATERIALS]
+        material_utils.add_fake_user_to_materials(genshin_materials)
 
         NextStepInvoker().invoke(
             self.next_step_idx, 

--- a/setup_wizard/genshin_set_up_geometry_nodes.py
+++ b/setup_wizard/genshin_set_up_geometry_nodes.py
@@ -87,6 +87,7 @@ class GI_OT_SetUpGeometryNodes(Operator, CustomOperatorProperties):
 
                 new_outline_material = outline_material.copy()
                 new_outline_material.name = new_outline_name
+                new_outline_material.use_fake_user = True
 
 
     def set_up_modifier_default_values(self, modifier, mesh):

--- a/setup_wizard/utils/material_utils.py
+++ b/setup_wizard/utils/material_utils.py
@@ -1,0 +1,3 @@
+def add_fake_user_to_materials(materials):
+    for material in materials:
+        material.use_fake_user = True


### PR DESCRIPTION
### Description
Adds fake users to all imported materials during the Setup Wizard setup process to prevent Blender garbage collection from removing required materials when reopening the file

### Change Summary
- Adds fake user to materials when importing character model, shader materials and shader material outlines
- Prevents Blender garbage collection from removing these required materials
- Closes #30