### PR TITLE
feat: initial Setup Wizard NPC support

### DIFF
--- a/setup_wizard/domain/shader_configurator.py
+++ b/setup_wizard/domain/shader_configurator.py
@@ -1,0 +1,20 @@
+class ShaderConfigurator:
+    v1_node_name_mapping = {}
+
+    v2_node_name_mapping = {
+        'miHoYo - Genshin Impact': 'Group.006',
+    }
+
+    def update_shader_value(self, materials, node_name, input_name, value):
+        for material in materials:
+            internal_node_name = self.v2_node_name_mapping.get(node_name) if \
+                self.v2_node_name_mapping.get(node_name) else self.v1_node_name_mapping.get(node_name)
+
+            shader_node = material.node_tree.nodes.get(internal_node_name)
+            shader_node_inputs = shader_node.inputs if shader_node else None
+
+            if shader_node_inputs:
+                shader_node_input = shader_node_inputs.get(input_name)
+
+                if shader_node_input:
+                    shader_node_input.default_value = value

--- a/setup_wizard/domain/texture_importers.py
+++ b/setup_wizard/domain/texture_importers.py
@@ -47,7 +47,7 @@ class GenshinTextureImporter:
         material.node_tree.nodes[f'{type.value}_Lightmap_UV1'].image = img
         self.setup_dress_textures(f'{type.value}_Lightmap', img)
 
-    def set_normalmap_texture(self, type:TextureType, material, img):
+    def set_normalmap_texture(self, type: TextureType, material, img):
         img.colorspace_settings.name='Non-Color'
         material.node_tree.nodes[f'{type.value}_Normalmap_UV0'].image = img
         material.node_tree.nodes[f'{type.value}_Normalmap_UV1'].image = img
@@ -59,15 +59,12 @@ class GenshinTextureImporter:
         self.plug_normal_map('miHoYo - Genshin Dress1', 'MUTE IF ONLY 1 UV MAP EXISTS')
         self.plug_normal_map('miHoYo - Genshin Dress2', 'MUTE IF ONLY 1 UV MAP EXISTS')
 
-    def set_hair_shadow_ramp_texture(self, img):
-        bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
+    def set_shadow_ramp_texture(self, type: TextureType, img):
+        bpy.data.node_groups[f'{type.value} Shadow Ramp'].nodes[f'{type.value}_Shadow_Ramp'].image = img
 
-    def set_body_shadow_ramp_texture(self, img):
-        bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
-
-    def set_body_specular_ramp_texture(self, img):
+    def set_specular_ramp_texture(self, type: TextureType, img):
         img.colorspace_settings.name='Non-Color'
-        bpy.data.node_groups['Body Specular Ramp'].nodes['Body_Specular_Ramp'].image = img        
+        bpy.data.node_groups[f'{type.value} Specular Ramp'].nodes[f'{type.value}_Specular_Ramp'].image = img        
 
     def set_face_diffuse_texture(self, face_material, img):
         face_material.node_tree.nodes['Face_Diffuse'].image = img        
@@ -159,7 +156,7 @@ class GenshinAvatarTextureImporter(GenshinTextureImporter):
                 elif "Hair_Normalmap" in file:
                     self.set_normalmap_texture(TextureType.HAIR, hair_material, img)
                 elif "Hair_Shadow_Ramp" in file:
-                    bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
+                    self.set_shadow_ramp_texture(TextureType.HAIR, img)
                 elif "Body_Diffuse" in file:
                     self.set_diffuse_texture(TextureType.BODY, body_material, img)
                 elif "Body_Lightmap" in file:
@@ -167,20 +164,17 @@ class GenshinAvatarTextureImporter(GenshinTextureImporter):
                 elif "Body_Normalmap" in file:
                     self.set_normalmap_texture(TextureType.BODY, body_material, img)
                 elif "Body_Shadow_Ramp" in file:
-                    bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
-                elif "Body_Specular_Ramp" in file or "Tex_Specular_Ramp" in file :
-                    img.colorspace_settings.name='Non-Color'
-                    bpy.data.node_groups['Body Specular Ramp'].nodes['Body_Specular_Ramp'].image = img
+                    self.set_shadow_ramp_texture(TextureType.BODY, img)
+                elif "Body_Specular_Ramp" in file or "Tex_Specular_Ramp" in file:
+                    self.set_specular_ramp_texture(TextureType.BODY, img)
                 elif "Face_Diffuse" in file:
-                    face_material.node_tree.nodes['Face_Diffuse'].image = img
+                    self.set_face_diffuse_texture(face_material, img)
                 elif "Face_Shadow" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    face_material.node_tree.nodes['Face_Shadow'].image = img
+                    self.set_face_shadow_texture(face_material, img)
                 elif "FaceLightmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    bpy.data.node_groups['Face Lightmap'].nodes['Face_Lightmap'].image = img
+                    self.set_face_lightmap_texture(img)
                 elif "MetalMap" in file:
-                    bpy.data.node_groups['Metallic Matcap'].nodes['MetalMap'].image = img
+                    self.set_metalmap_texture(img)
                 else:
                     pass
             break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files
@@ -212,7 +206,7 @@ class GenshinNPCTextureImporter(GenshinTextureImporter):
                     self.set_normalmap_texture(TextureType.HAIR, hair_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Hair', 'Shadow_Ramp'], file):
-                    bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
+                    self.set_shadow_ramp_texture(TextureType.HAIR, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Body', 'Diffuse'], file):
                     self.set_diffuse_texture(TextureType.BODY, body_material, img)
@@ -224,26 +218,23 @@ class GenshinNPCTextureImporter(GenshinTextureImporter):
                     self.set_normalmap_texture(TextureType.BODY, body_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Body', 'Shadow_Ramp'], file):
-                    bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
+                    self.set_shadow_ramp_texture(TextureType.BODY, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Body', 'Specular_Ramp'], file) or \
                     self.is_texture_identifiers_in_texture_name(['Tex', 'Specular_Ramp'], file):
-                    img.colorspace_settings.name='Non-Color'
-                    bpy.data.node_groups['Body Specular Ramp'].nodes['Body_Specular_Ramp'].image = img
+                    self.set_specular_ramp_texture(TextureType.BODY, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Face', 'Diffuse'], file):
-                    face_material.node_tree.nodes['Face_Diffuse'].image = img
+                    self.set_face_diffuse_texture(face_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['NPC', 'Face', 'Lightmap'], file):
-                    img.colorspace_settings.name='Non-Color'
-                    face_material.node_tree.nodes['Face_Shadow'].image = img
+                    self.set_face_shadow_texture(face_material, img)  # Not a typo (set face shadow as NPC lightmap)
 
                 elif self.is_texture_identifiers_in_texture_name(['Face', 'Lightmap'], file):
-                    img.colorspace_settings.name='Non-Color'
-                    bpy.data.node_groups['Face Lightmap'].nodes['Face_Lightmap'].image = img
+                    self.set_face_lightmap_texture(img)
 
-                elif "MetalMap" in file:
-                    bpy.data.node_groups['Metallic Matcap'].nodes['MetalMap'].image = img
+                elif self.is_texture_identifiers_in_texture_name(['MetalMap'], file):
+                    self.set_metalmap_texture(img)
 
                 else:
                     pass

--- a/setup_wizard/domain/texture_importers.py
+++ b/setup_wizard/domain/texture_importers.py
@@ -1,0 +1,297 @@
+from enum import Enum, auto
+import bpy
+
+import os
+
+from setup_wizard.import_order import get_actual_material_name_for_dress
+
+
+class TextureImporterType(Enum):
+    AVATAR = auto()
+    NPC = auto()
+
+
+class TextureImporterFactory:
+    def create(texture_importer_type):
+        if texture_importer_type == TextureImporterType.AVATAR:
+            return GenshinAvatarTextureImporter()
+        elif texture_importer_type == TextureImporterType.NPC:
+            return GenshinNPCTextureImporter()
+        else:
+            print(f'Unknown TextureImporterType: {texture_importer_type}')
+
+
+class GenshinTextureImporter:
+    def import_textures(self, directory):
+        raise NotImplementedError()
+
+    def is_texture_identifiers_in_texture_name(self, texture_identifiers, texture_name):
+        for texture_identifier in texture_identifiers:
+            if texture_identifier not in texture_name:
+                return False
+        return True
+
+    def set_hair_diffuse_texture(self, hair_material, img):
+        hair_material.node_tree.nodes['Hair_Diffuse_UV0'].image = img
+        hair_material.node_tree.nodes['Hair_Diffuse_UV1'].image = img
+        self.setup_dress_textures('Hair_Diffuse', img)
+
+    def set_hair_lightmap_texture(self, hair_material, img):
+        img.colorspace_settings.name='Non-Color'
+        hair_material.node_tree.nodes['Hair_Lightmap_UV0'].image = img
+        hair_material.node_tree.nodes['Hair_Lightmap_UV1'].image = img
+        self.setup_dress_textures('Hair_Lightmap', img)
+
+    def set_hair_normal_map_texture(self, hair_material, img):
+        img.colorspace_settings.name='Non-Color'
+        hair_material.node_tree.nodes['Hair_Normalmap_UV0'].image = img
+        hair_material.node_tree.nodes['Hair_Normalmap_UV1'].image = img
+        self.setup_dress_textures('Hair_Normalmap', img)
+        self.plug_normal_map('miHoYo - Genshin Hair', 'MUTE IF ONLY 1 UV MAP EXISTS')
+
+    def set_hair_shadow_ramp_texture(self, img):
+        bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
+
+    def set_body_diffuse_texture(self, body_material, img):
+        body_material.node_tree.nodes['Body_Diffuse_UV0'].image = img
+        body_material.node_tree.nodes['Body_Diffuse_UV1'].image = img
+        self.setup_dress_textures('Body_Diffuse', img)
+
+    def set_body_lightmap_texture(self, body_material, img):
+        img.colorspace_settings.name='Non-Color'
+        body_material.node_tree.nodes['Body_Lightmap_UV0'].image = img
+        body_material.node_tree.nodes['Body_Lightmap_UV1'].image = img
+        self.setup_dress_textures('Body_Lightmap', img)
+
+    def set_body_normalmap_texture(self, body_material, img):
+        img.colorspace_settings.name='Non-Color'
+        body_material.node_tree.nodes['Body_Normalmap_UV0'].image = img
+        body_material.node_tree.nodes['Body_Normalmap_UV1'].image = img
+        self.setup_dress_textures('Body_Normalmap', img)
+        self.plug_normal_map('miHoYo - Genshin Body', 'MUTE IF ONLY 1 UV MAP EXISTS')
+        self.plug_normal_map('miHoYo - Genshin Dress', 'MUTE IF ONLY 1 UV MAP EXISTS')
+
+    def set_body_shadow_ramp_texture(self, img):
+        bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
+
+    def set_body_specular_ramp_texture(self, img):
+        img.colorspace_settings.name='Non-Color'
+        bpy.data.node_groups['Body Specular Ramp'].nodes['Body_Specular_Ramp'].image = img        
+
+    def set_face_diffuse_texture(self, face_material, img):
+        face_material.node_tree.nodes['Face_Diffuse'].image = img        
+
+    def set_face_shadow_texture(self, face_material, img):
+        img.colorspace_settings.name='Non-Color'
+        face_material.node_tree.nodes['Face_Shadow'].image = img        
+
+    def set_face_lightmap_texture(self, img):
+        img.colorspace_settings.name='Non-Color'
+        bpy.data.node_groups['Face Lightmap'].nodes['Face_Lightmap'].image = img
+
+    def set_metalmap_texture(self, img):
+        bpy.data.node_groups['Metallic Matcap'].nodes['MetalMap'].image = img
+
+    def setup_dress_textures(self, texture_name, texture_img):
+        shader_dress_materials = [material for material in bpy.data.materials if 'Genshin Dress' in material.name]
+        shader_cloak_materials = [material for material in bpy.data.materials
+                                  if 'Genshin Arm' in material.name or 'Genshin Cloak' in material.name]
+
+        # TODO: Refactor this for sure!
+        # Specific case for Xiao (the only character with an Arm material)
+        # Specific case for Dainsleif (the only character with a Cloak material)
+        # Technically Paimon has one, but we ignore it
+        if shader_cloak_materials:
+            original_cloak_material = [material for material in bpy.data.materials if material.name.endswith(
+                shader_cloak_materials[0].name.split(' ')[-1]
+            )][0]  # the material that ends with 'Dress', 'Dress1', 'Dress2'
+            actual_cloak_material = get_actual_material_name_for_dress(original_cloak_material.name)
+            if actual_cloak_material in texture_name:
+                material_shader_nodes = bpy.data.materials.get(shader_cloak_materials[0].name).node_tree.nodes
+                material_shader_nodes.get(f'{texture_name}_UV0').image = texture_img
+                material_shader_nodes.get(f'{texture_name}_UV1').image = texture_img
+
+        for shader_dress_material in shader_dress_materials:
+            original_dress_material = [material for material in bpy.data.materials if material.name.endswith(
+                shader_dress_material.name.split(' ')[-1]
+            )][0]  # the material that ends with 'Dress', 'Dress1', 'Dress2'
+
+            actual_material = get_actual_material_name_for_dress(original_dress_material.name)
+            if actual_material in texture_name:
+                print(f'Importing texture "{texture_name}" onto material "{shader_dress_material.name}"')
+                material_shader_nodes = bpy.data.materials.get(shader_dress_material.name).node_tree.nodes
+                material_shader_nodes.get(f'{texture_name}_UV0').image = texture_img
+                material_shader_nodes.get(f'{texture_name}_UV1').image = texture_img
+                return
+
+    '''
+    Deprecated: No longer needed after shader rewrite because normal map is plugged by default
+    Still maintains backward compatibility by only trying this if `label_name` is found in the node tree.
+    '''
+    def plug_normal_map(self, shader_material_name, label_name):
+        shader_group_material_name = 'Group.001'
+        shader_material = bpy.data.materials.get(shader_material_name)
+
+        if shader_material:
+            normal_map_node_color_outputs = [node.outputs.get('Color') for node in shader_material.node_tree.nodes \
+                if node.label == label_name and not node.outputs.get('Color').is_linked]
+            
+            if normal_map_node_color_outputs:
+                normal_map_node_color_output = normal_map_node_color_outputs[0]
+                normal_map_input = shader_material.node_tree.nodes.get(shader_group_material_name).inputs.get('Normal Map')
+
+                bpy.data.materials.get(shader_material_name).node_tree.links.new(
+                    normal_map_node_color_output,
+                    normal_map_input
+                )
+
+
+class GenshinAvatarTextureImporter(GenshinTextureImporter):
+    def import_textures(self, directory):
+        for name, folder, files in os.walk(directory):
+            for file in files:
+                # load the file with the correct alpha mode
+                img_path = directory + "/" + file
+                img = bpy.data.images.load(filepath = img_path, check_existing=True)
+                img.alpha_mode = 'CHANNEL_PACKED'
+
+                hair_material = bpy.data.materials.get('miHoYo - Genshin Hair')
+                face_material = bpy.data.materials.get('miHoYo - Genshin Face')
+                body_material = bpy.data.materials.get('miHoYo - Genshin Body')
+                
+                # Implement the texture in the correct node
+                print(f'Importing texture {file}')
+                if "Hair_Diffuse" in file and "Eff" not in file:
+                    hair_material.node_tree.nodes['Hair_Diffuse_UV0'].image = img
+                    hair_material.node_tree.nodes['Hair_Diffuse_UV1'].image = img
+                    self.setup_dress_textures('Hair_Diffuse', img)
+                elif "Hair_Lightmap" in file:
+                    img.colorspace_settings.name='Non-Color'
+                    hair_material.node_tree.nodes['Hair_Lightmap_UV0'].image = img
+                    hair_material.node_tree.nodes['Hair_Lightmap_UV1'].image = img
+                    self.setup_dress_textures('Hair_Lightmap', img)
+                elif "Hair_Normalmap" in file:
+                    img.colorspace_settings.name='Non-Color'
+                    hair_material.node_tree.nodes['Hair_Normalmap_UV0'].image = img
+                    hair_material.node_tree.nodes['Hair_Normalmap_UV1'].image = img
+                    self.setup_dress_textures('Hair_Normalmap', img)
+                    self.plug_normal_map('miHoYo - Genshin Hair', 'MUTE IF ONLY 1 UV MAP EXISTS')
+                elif "Hair_Shadow_Ramp" in file:
+                    bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
+                elif "Body_Diffuse" in file:
+                    body_material.node_tree.nodes['Body_Diffuse_UV0'].image = img
+                    body_material.node_tree.nodes['Body_Diffuse_UV1'].image = img
+                    self.setup_dress_textures('Body_Diffuse', img)
+                elif "Body_Lightmap" in file:
+                    img.colorspace_settings.name='Non-Color'
+                    body_material.node_tree.nodes['Body_Lightmap_UV0'].image = img
+                    body_material.node_tree.nodes['Body_Lightmap_UV1'].image = img
+                    self.setup_dress_textures('Body_Lightmap', img)
+                elif "Body_Normalmap" in file:
+                    img.colorspace_settings.name='Non-Color'
+                    body_material.node_tree.nodes['Body_Normalmap_UV0'].image = img
+                    body_material.node_tree.nodes['Body_Normalmap_UV1'].image = img
+                    self.setup_dress_textures('Body_Normalmap', img)
+                    self.plug_normal_map('miHoYo - Genshin Body', 'MUTE IF ONLY 1 UV MAP EXISTS')
+                    self.plug_normal_map('miHoYo - Genshin Dress', 'MUTE IF ONLY 1 UV MAP EXISTS')
+                elif "Body_Shadow_Ramp" in file:
+                    bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
+                elif "Body_Specular_Ramp" in file or "Tex_Specular_Ramp" in file :
+                    img.colorspace_settings.name='Non-Color'
+                    bpy.data.node_groups['Body Specular Ramp'].nodes['Body_Specular_Ramp'].image = img
+                elif "Face_Diffuse" in file:
+                    face_material.node_tree.nodes['Face_Diffuse'].image = img
+                elif "Face_Shadow" in file:
+                    img.colorspace_settings.name='Non-Color'
+                    face_material.node_tree.nodes['Face_Shadow'].image = img
+                elif "FaceLightmap" in file:
+                    img.colorspace_settings.name='Non-Color'
+                    bpy.data.node_groups['Face Lightmap'].nodes['Face_Lightmap'].image = img
+                elif "MetalMap" in file:
+                    bpy.data.node_groups['Metallic Matcap'].nodes['MetalMap'].image = img
+                else:
+                    pass
+            break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files
+
+
+class GenshinNPCTextureImporter(GenshinTextureImporter):
+    def import_textures(self, directory):
+        for name, folder, files in os.walk(directory):
+            for file in files:
+                # load the file with the correct alpha mode
+                img_path = directory + "/" + file
+                img = bpy.data.images.load(filepath = img_path, check_existing=True)
+                img.alpha_mode = 'CHANNEL_PACKED'
+
+                hair_material = bpy.data.materials.get('miHoYo - Genshin Hair')
+                face_material = bpy.data.materials.get('miHoYo - Genshin Face')
+                body_material = bpy.data.materials.get('miHoYo - Genshin Body')
+                
+                # Implement the texture in the correct node
+                print(f'Importing texture {file}')
+                if self.is_texture_identifiers_in_texture_name(['Hair', 'Diffuse'], file) and \
+                    not self.is_texture_identifiers_in_texture_name(['Eff'], file):
+                    hair_material.node_tree.nodes['Hair_Diffuse_UV0'].image = img
+                    hair_material.node_tree.nodes['Hair_Diffuse_UV1'].image = img
+                    self.setup_dress_textures('Hair_Diffuse', img)
+
+                elif self.is_texture_identifiers_in_texture_name(['Hair', 'Lightmap'], file):
+                    img.colorspace_settings.name='Non-Color'
+                    hair_material.node_tree.nodes['Hair_Lightmap_UV0'].image = img
+                    hair_material.node_tree.nodes['Hair_Lightmap_UV1'].image = img
+                    self.setup_dress_textures('Hair_Lightmap', img)
+
+                elif self.is_texture_identifiers_in_texture_name(['Hair', 'Normalmap'], file):
+                    img.colorspace_settings.name='Non-Color'
+                    hair_material.node_tree.nodes['Hair_Normalmap_UV0'].image = img
+                    hair_material.node_tree.nodes['Hair_Normalmap_UV1'].image = img
+                    self.setup_dress_textures('Hair_Normalmap', img)
+                    self.plug_normal_map('miHoYo - Genshin Hair', 'MUTE IF ONLY 1 UV MAP EXISTS')
+
+                elif self.is_texture_identifiers_in_texture_name(['Hair', 'Shadow_Ramp'], file):
+                    bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
+
+                elif self.is_texture_identifiers_in_texture_name(['Body', 'Diffuse'], file):
+                    body_material.node_tree.nodes['Body_Diffuse_UV0'].image = img
+                    body_material.node_tree.nodes['Body_Diffuse_UV1'].image = img
+                    self.setup_dress_textures('Body_Diffuse', img)
+
+                elif self.is_texture_identifiers_in_texture_name(['Body', 'Lightmap'], file):
+                    img.colorspace_settings.name='Non-Color'
+                    body_material.node_tree.nodes['Body_Lightmap_UV0'].image = img
+                    body_material.node_tree.nodes['Body_Lightmap_UV1'].image = img
+                    self.setup_dress_textures('Body_Lightmap', img)
+
+                elif self.is_texture_identifiers_in_texture_name(['Body', 'Normalmap'], file):
+                    img.colorspace_settings.name='Non-Color'
+                    body_material.node_tree.nodes['Body_Normalmap_UV0'].image = img
+                    body_material.node_tree.nodes['Body_Normalmap_UV1'].image = img
+                    self.setup_dress_textures('Body_Normalmap', img)
+                    self.plug_normal_map('miHoYo - Genshin Body', 'MUTE IF ONLY 1 UV MAP EXISTS')
+                    self.plug_normal_map('miHoYo - Genshin Dress', 'MUTE IF ONLY 1 UV MAP EXISTS')
+
+                elif self.is_texture_identifiers_in_texture_name(['Body', 'Shadow_Ramp'], file):
+                    bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
+
+                elif self.is_texture_identifiers_in_texture_name(['Body', 'Specular_Ramp'], file) or \
+                    self.is_texture_identifiers_in_texture_name(['Tex', 'Specular_Ramp'], file):
+                    img.colorspace_settings.name='Non-Color'
+                    bpy.data.node_groups['Body Specular Ramp'].nodes['Body_Specular_Ramp'].image = img
+
+                elif self.is_texture_identifiers_in_texture_name(['Face', 'Diffuse'], file):
+                    face_material.node_tree.nodes['Face_Diffuse'].image = img
+
+                elif self.is_texture_identifiers_in_texture_name(['NPC', 'Face', 'Lightmap'], file):
+                    img.colorspace_settings.name='Non-Color'
+                    face_material.node_tree.nodes['Face_Shadow'].image = img
+
+                elif self.is_texture_identifiers_in_texture_name(['Face', 'Lightmap'], file):
+                    img.colorspace_settings.name='Non-Color'
+                    bpy.data.node_groups['Face Lightmap'].nodes['Face_Lightmap'].image = img
+
+                elif "MetalMap" in file:
+                    bpy.data.node_groups['Metallic Matcap'].nodes['MetalMap'].image = img
+
+                else:
+                    pass
+            break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files

--- a/setup_wizard/domain/texture_importers.py
+++ b/setup_wizard/domain/texture_importers.py
@@ -11,6 +11,11 @@ class TextureImporterType(Enum):
     NPC = auto()
 
 
+class TextureType(Enum):
+    HAIR = 'Hair'
+    BODY = 'Body'
+
+
 class TextureImporterFactory:
     def create(texture_importer_type):
         if texture_importer_type == TextureImporterType.AVATAR:
@@ -31,45 +36,31 @@ class GenshinTextureImporter:
                 return False
         return True
 
-    def set_hair_diffuse_texture(self, hair_material, img):
-        hair_material.node_tree.nodes['Hair_Diffuse_UV0'].image = img
-        hair_material.node_tree.nodes['Hair_Diffuse_UV1'].image = img
-        self.setup_dress_textures('Hair_Diffuse', img)
+    def set_diffuse_texture(self, type: TextureType, material, img):
+        material.node_tree.nodes[f'{type.value}_Diffuse_UV0'].image = img
+        material.node_tree.nodes[f'{type.value}_Diffuse_UV1'].image = img
+        self.setup_dress_textures(f'{type.value}_Diffuse', img)
 
-    def set_hair_lightmap_texture(self, hair_material, img):
+    def set_lightmap_texture(self, type: TextureType, material, img):
         img.colorspace_settings.name='Non-Color'
-        hair_material.node_tree.nodes['Hair_Lightmap_UV0'].image = img
-        hair_material.node_tree.nodes['Hair_Lightmap_UV1'].image = img
-        self.setup_dress_textures('Hair_Lightmap', img)
+        material.node_tree.nodes[f'{type.value}_Lightmap_UV0'].image = img
+        material.node_tree.nodes[f'{type.value}_Lightmap_UV1'].image = img
+        self.setup_dress_textures(f'{type.value}_Lightmap', img)
 
-    def set_hair_normal_map_texture(self, hair_material, img):
+    def set_normalmap_texture(self, type:TextureType, material, img):
         img.colorspace_settings.name='Non-Color'
-        hair_material.node_tree.nodes['Hair_Normalmap_UV0'].image = img
-        hair_material.node_tree.nodes['Hair_Normalmap_UV1'].image = img
-        self.setup_dress_textures('Hair_Normalmap', img)
-        self.plug_normal_map('miHoYo - Genshin Hair', 'MUTE IF ONLY 1 UV MAP EXISTS')
+        material.node_tree.nodes[f'{type.value}_Normalmap_UV0'].image = img
+        material.node_tree.nodes[f'{type.value}_Normalmap_UV1'].image = img
+        self.setup_dress_textures(f'{type.value}_Normalmap', img)
+
+        # Deprecated. Tries only if it exists. Only for V1 Shader
+        self.plug_normal_map(f'miHoYo - Genshin {type.value}', 'MUTE IF ONLY 1 UV MAP EXISTS')
+        self.plug_normal_map('miHoYo - Genshin Dress', 'MUTE IF ONLY 1 UV MAP EXISTS')
+        self.plug_normal_map('miHoYo - Genshin Dress1', 'MUTE IF ONLY 1 UV MAP EXISTS')
+        self.plug_normal_map('miHoYo - Genshin Dress2', 'MUTE IF ONLY 1 UV MAP EXISTS')
 
     def set_hair_shadow_ramp_texture(self, img):
         bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
-
-    def set_body_diffuse_texture(self, body_material, img):
-        body_material.node_tree.nodes['Body_Diffuse_UV0'].image = img
-        body_material.node_tree.nodes['Body_Diffuse_UV1'].image = img
-        self.setup_dress_textures('Body_Diffuse', img)
-
-    def set_body_lightmap_texture(self, body_material, img):
-        img.colorspace_settings.name='Non-Color'
-        body_material.node_tree.nodes['Body_Lightmap_UV0'].image = img
-        body_material.node_tree.nodes['Body_Lightmap_UV1'].image = img
-        self.setup_dress_textures('Body_Lightmap', img)
-
-    def set_body_normalmap_texture(self, body_material, img):
-        img.colorspace_settings.name='Non-Color'
-        body_material.node_tree.nodes['Body_Normalmap_UV0'].image = img
-        body_material.node_tree.nodes['Body_Normalmap_UV1'].image = img
-        self.setup_dress_textures('Body_Normalmap', img)
-        self.plug_normal_map('miHoYo - Genshin Body', 'MUTE IF ONLY 1 UV MAP EXISTS')
-        self.plug_normal_map('miHoYo - Genshin Dress', 'MUTE IF ONLY 1 UV MAP EXISTS')
 
     def set_body_shadow_ramp_texture(self, img):
         bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
@@ -158,42 +149,23 @@ class GenshinAvatarTextureImporter(GenshinTextureImporter):
                 hair_material = bpy.data.materials.get('miHoYo - Genshin Hair')
                 face_material = bpy.data.materials.get('miHoYo - Genshin Face')
                 body_material = bpy.data.materials.get('miHoYo - Genshin Body')
-                
+
                 # Implement the texture in the correct node
                 print(f'Importing texture {file}')
                 if "Hair_Diffuse" in file and "Eff" not in file:
-                    hair_material.node_tree.nodes['Hair_Diffuse_UV0'].image = img
-                    hair_material.node_tree.nodes['Hair_Diffuse_UV1'].image = img
-                    self.setup_dress_textures('Hair_Diffuse', img)
+                    self.set_diffuse_texture(TextureType.HAIR, hair_material, img)
                 elif "Hair_Lightmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    hair_material.node_tree.nodes['Hair_Lightmap_UV0'].image = img
-                    hair_material.node_tree.nodes['Hair_Lightmap_UV1'].image = img
-                    self.setup_dress_textures('Hair_Lightmap', img)
+                    self.set_lightmap_texture(TextureType.HAIR, hair_material, img)
                 elif "Hair_Normalmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    hair_material.node_tree.nodes['Hair_Normalmap_UV0'].image = img
-                    hair_material.node_tree.nodes['Hair_Normalmap_UV1'].image = img
-                    self.setup_dress_textures('Hair_Normalmap', img)
-                    self.plug_normal_map('miHoYo - Genshin Hair', 'MUTE IF ONLY 1 UV MAP EXISTS')
+                    self.set_normalmap_texture(TextureType.HAIR, hair_material, img)
                 elif "Hair_Shadow_Ramp" in file:
                     bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
                 elif "Body_Diffuse" in file:
-                    body_material.node_tree.nodes['Body_Diffuse_UV0'].image = img
-                    body_material.node_tree.nodes['Body_Diffuse_UV1'].image = img
-                    self.setup_dress_textures('Body_Diffuse', img)
+                    self.set_diffuse_texture(TextureType.BODY, body_material, img)
                 elif "Body_Lightmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    body_material.node_tree.nodes['Body_Lightmap_UV0'].image = img
-                    body_material.node_tree.nodes['Body_Lightmap_UV1'].image = img
-                    self.setup_dress_textures('Body_Lightmap', img)
+                    self.set_lightmap_texture(TextureType.BODY, body_material, img)
                 elif "Body_Normalmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    body_material.node_tree.nodes['Body_Normalmap_UV0'].image = img
-                    body_material.node_tree.nodes['Body_Normalmap_UV1'].image = img
-                    self.setup_dress_textures('Body_Normalmap', img)
-                    self.plug_normal_map('miHoYo - Genshin Body', 'MUTE IF ONLY 1 UV MAP EXISTS')
-                    self.plug_normal_map('miHoYo - Genshin Dress', 'MUTE IF ONLY 1 UV MAP EXISTS')
+                    self.set_normalmap_texture(TextureType.BODY, body_material, img)
                 elif "Body_Shadow_Ramp" in file:
                     bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
                 elif "Body_Specular_Ramp" in file or "Tex_Specular_Ramp" in file :
@@ -226,49 +198,30 @@ class GenshinNPCTextureImporter(GenshinTextureImporter):
                 hair_material = bpy.data.materials.get('miHoYo - Genshin Hair')
                 face_material = bpy.data.materials.get('miHoYo - Genshin Face')
                 body_material = bpy.data.materials.get('miHoYo - Genshin Body')
-                
+
                 # Implement the texture in the correct node
                 print(f'Importing texture {file}')
                 if self.is_texture_identifiers_in_texture_name(['Hair', 'Diffuse'], file) and \
                     not self.is_texture_identifiers_in_texture_name(['Eff'], file):
-                    hair_material.node_tree.nodes['Hair_Diffuse_UV0'].image = img
-                    hair_material.node_tree.nodes['Hair_Diffuse_UV1'].image = img
-                    self.setup_dress_textures('Hair_Diffuse', img)
+                    self.set_diffuse_texture(TextureType.HAIR, hair_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Hair', 'Lightmap'], file):
-                    img.colorspace_settings.name='Non-Color'
-                    hair_material.node_tree.nodes['Hair_Lightmap_UV0'].image = img
-                    hair_material.node_tree.nodes['Hair_Lightmap_UV1'].image = img
-                    self.setup_dress_textures('Hair_Lightmap', img)
+                    self.set_lightmap_texture(TextureType.HAIR, hair_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Hair', 'Normalmap'], file):
-                    img.colorspace_settings.name='Non-Color'
-                    hair_material.node_tree.nodes['Hair_Normalmap_UV0'].image = img
-                    hair_material.node_tree.nodes['Hair_Normalmap_UV1'].image = img
-                    self.setup_dress_textures('Hair_Normalmap', img)
-                    self.plug_normal_map('miHoYo - Genshin Hair', 'MUTE IF ONLY 1 UV MAP EXISTS')
+                    self.set_normalmap_texture(TextureType.HAIR, hair_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Hair', 'Shadow_Ramp'], file):
                     bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
 
                 elif self.is_texture_identifiers_in_texture_name(['Body', 'Diffuse'], file):
-                    body_material.node_tree.nodes['Body_Diffuse_UV0'].image = img
-                    body_material.node_tree.nodes['Body_Diffuse_UV1'].image = img
-                    self.setup_dress_textures('Body_Diffuse', img)
+                    self.set_diffuse_texture(TextureType.BODY, body_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Body', 'Lightmap'], file):
-                    img.colorspace_settings.name='Non-Color'
-                    body_material.node_tree.nodes['Body_Lightmap_UV0'].image = img
-                    body_material.node_tree.nodes['Body_Lightmap_UV1'].image = img
-                    self.setup_dress_textures('Body_Lightmap', img)
+                    self.set_lightmap_texture(TextureType.BODY, body_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Body', 'Normalmap'], file):
-                    img.colorspace_settings.name='Non-Color'
-                    body_material.node_tree.nodes['Body_Normalmap_UV0'].image = img
-                    body_material.node_tree.nodes['Body_Normalmap_UV1'].image = img
-                    self.setup_dress_textures('Body_Normalmap', img)
-                    self.plug_normal_map('miHoYo - Genshin Body', 'MUTE IF ONLY 1 UV MAP EXISTS')
-                    self.plug_normal_map('miHoYo - Genshin Dress', 'MUTE IF ONLY 1 UV MAP EXISTS')
+                    self.set_normalmap_texture(TextureType.BODY, body_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Body', 'Shadow_Ramp'], file):
                     bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img

--- a/setup_wizard/genshin_import_character_model.py
+++ b/setup_wizard/genshin_import_character_model.py
@@ -66,6 +66,8 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
         original_language = bpy.context.preferences.view.language
         try:
             # Blender's FBX import has some silent issue when importing in different languages. Unsure why.
+            # TODO: Confirm if this issue is due to the Color Attribute name being named differently in each language
+            # TODO: rename_mesh_color_attribute_name() should address this issue and not require us to set language
             bpy.context.preferences.view.language = 'en_US'
             self.import_character_model(character_model_folder_file_path)
             self.reset_pose_location_and_rotation()

--- a/setup_wizard/genshin_import_materials.py
+++ b/setup_wizard/genshin_import_materials.py
@@ -88,7 +88,8 @@ class GI_OT_GenshinImportMaterials(Operator, ImportHelper, CustomOperatorPropert
             shader_blend_file_path = blend_file_with_genshin_materials or default_blend_file_path
             bpy.ops.wm.append(
                 directory=shader_blend_file_path,
-                files=NAMES_OF_GENSHIN_MATERIALS
+                files=NAMES_OF_GENSHIN_MATERIALS,
+                set_fake=True
             )
         except RuntimeError as ex:
             super().clear_custom_properties()

--- a/setup_wizard/genshin_import_textures.py
+++ b/setup_wizard/genshin_import_textures.py
@@ -9,6 +9,7 @@ from bpy_extras.io_utils import ImportHelper
 from bpy.props import StringProperty
 from bpy.types import Operator
 import os
+from setup_wizard.domain.texture_importers import GenshinTextureImporter, TextureImporterFactory, TextureImporterType
 
 from setup_wizard.import_order import CHARACTER_MODEL_FOLDER_FILE_PATH, NextStepInvoker, cache_using_cache_key, get_cache
 from setup_wizard.import_order import get_actual_material_name_for_dress
@@ -51,71 +52,12 @@ class GI_OT_GenshinImportTextures(Operator, ImportHelper, CustomOperatorProperti
                 high_level_step_name=self.high_level_step_name
             )
             return {'FINISHED'}
-        
-        for name, folder, files in os.walk(directory):
-            for file in files:
-                # load the file with the correct alpha mode
-                img_path = directory + "/" + file
-                img = bpy.data.images.load(filepath = img_path, check_existing=True)
-                img.alpha_mode = 'CHANNEL_PACKED'
 
-                hair_material = bpy.data.materials.get('miHoYo - Genshin Hair')
-                face_material = bpy.data.materials.get('miHoYo - Genshin Face')
-                body_material = bpy.data.materials.get('miHoYo - Genshin Body')
-                
-                # Implement the texture in the correct node
-                self.report({'INFO'}, f'Importing texture {file}')
-                if "Hair_Diffuse" in file and "Eff" not in file:
-                    hair_material.node_tree.nodes['Hair_Diffuse_UV0'].image = img
-                    hair_material.node_tree.nodes['Hair_Diffuse_UV1'].image = img
-                    self.setup_dress_textures('Hair_Diffuse', img)
-                elif "Hair_Lightmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    hair_material.node_tree.nodes['Hair_Lightmap_UV0'].image = img
-                    hair_material.node_tree.nodes['Hair_Lightmap_UV1'].image = img
-                    self.setup_dress_textures('Hair_Lightmap', img)
-                elif "Hair_Normalmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    hair_material.node_tree.nodes['Hair_Normalmap_UV0'].image = img
-                    hair_material.node_tree.nodes['Hair_Normalmap_UV1'].image = img
-                    self.setup_dress_textures('Hair_Normalmap', img)
-                    self.plug_normal_map('miHoYo - Genshin Hair', 'MUTE IF ONLY 1 UV MAP EXISTS')
-                elif "Hair_Shadow_Ramp" in file:
-                    bpy.data.node_groups['Hair Shadow Ramp'].nodes['Hair_Shadow_Ramp'].image = img
-                elif "Body_Diffuse" in file:
-                    body_material.node_tree.nodes['Body_Diffuse_UV0'].image = img
-                    body_material.node_tree.nodes['Body_Diffuse_UV1'].image = img
-                    self.setup_dress_textures('Body_Diffuse', img)
-                elif "Body_Lightmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    body_material.node_tree.nodes['Body_Lightmap_UV0'].image = img
-                    body_material.node_tree.nodes['Body_Lightmap_UV1'].image = img
-                    self.setup_dress_textures('Body_Lightmap', img)
-                elif "Body_Normalmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    body_material.node_tree.nodes['Body_Normalmap_UV0'].image = img
-                    body_material.node_tree.nodes['Body_Normalmap_UV1'].image = img
-                    self.setup_dress_textures('Body_Normalmap', img)
-                    self.plug_normal_map('miHoYo - Genshin Body', 'MUTE IF ONLY 1 UV MAP EXISTS')
-                    self.plug_normal_map('miHoYo - Genshin Dress', 'MUTE IF ONLY 1 UV MAP EXISTS')
-                elif "Body_Shadow_Ramp" in file:
-                    bpy.data.node_groups['Body Shadow Ramp'].nodes['Body_Shadow_Ramp'].image = img
-                elif "Body_Specular_Ramp" in file or "Tex_Specular_Ramp" in file :
-                    img.colorspace_settings.name='Non-Color'
-                    bpy.data.node_groups['Body Specular Ramp'].nodes['Body_Specular_Ramp'].image = img
-                elif "Face_Diffuse" in file:
-                    face_material.node_tree.nodes['Face_Diffuse'].image = img
-                elif "Face_Shadow" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    face_material.node_tree.nodes['Face_Shadow'].image = img
-                elif "FaceLightmap" in file:
-                    img.colorspace_settings.name='Non-Color'
-                    bpy.data.node_groups['Face Lightmap'].nodes['Face_Lightmap'].image = img
-                elif "MetalMap" in file:
-                    bpy.data.node_groups['Metallic Matcap'].nodes['MetalMap'].image = img
-                else:
-                    pass
-            break  # IMPORTANT: We os.walk which also traverses through folders...we just want the files
+        texture_importer_type = TextureImporterType.AVATAR if \
+            [material_name for material_name, material in bpy.data.materials.items() if 'Avatar' in material_name] else \
+                TextureImporterType.NPC
+        texture_importer: GenshinTextureImporter = TextureImporterFactory.create(texture_importer_type)
+        texture_importer.import_textures(directory)
 
         self.report({'INFO'}, 'Imported textures')
         if cache_enabled and directory:

--- a/setup_wizard/genshin_replace_default_materials.py
+++ b/setup_wizard/genshin_replace_default_materials.py
@@ -89,7 +89,7 @@ class GI_OT_GenshinReplaceDefaultMaterials(Operator, CustomOperatorProperties):
             return 'Face'
         elif 'Body' in material_name:
             return 'Body'
-        elif 'Dress' in material_name:
+        elif 'Dress' in material_name:  # I don't think this is a valid case, either they use Hair or Body textures
             return 'Dress'
         else:
             return None

--- a/setup_wizard/genshin_replace_default_materials.py
+++ b/setup_wizard/genshin_replace_default_materials.py
@@ -47,7 +47,8 @@ class GI_OT_GenshinReplaceDefaultMaterials(Operator, CustomOperatorProperties):
         for mesh in meshes:
             for material_slot in mesh.material_slots:
                 material_name = material_slot.name
-                mesh_body_part_name = material_name.split('_')[-1]
+                mesh_body_part_name = self.__get_npc_mesh_body_part_name(material_name) if \
+                    material_name.startswith('NPC') else material_name.split('_')[-1]
                 genshin_material = bpy.data.materials.get(f'miHoYo - Genshin {mesh_body_part_name}')
 
                 if genshin_material:            
@@ -80,6 +81,18 @@ class GI_OT_GenshinReplaceDefaultMaterials(Operator, CustomOperatorProperties):
                     genshin_main_shader_node = genshin_material.node_tree.nodes.get('Group.001')
                     genshin_main_shader_node.node_tree = self.__clone_shader_node_and_rename(genshin_material, mesh_body_part_name)
         self.report({'INFO'}, 'Replaced default materials with Genshin shader materials...')
+
+    def __get_npc_mesh_body_part_name(self, material_name):
+        if 'Hair' in material_name:
+            return 'Hair'
+        elif 'Face' in material_name:
+            return 'Face'
+        elif 'Body' in material_name:
+            return 'Body'
+        elif 'Dress' in material_name:
+            return 'Dress'
+        else:
+            return None
 
     def __clone_material_and_rename(self, material_slot, mesh_body_part_name_template, mesh_body_part_name):
         new_material = bpy.data.materials.get(mesh_body_part_name_template).copy()

--- a/setup_wizard/genshin_replace_default_materials.py
+++ b/setup_wizard/genshin_replace_default_materials.py
@@ -51,9 +51,9 @@ class GI_OT_GenshinReplaceDefaultMaterials(Operator, CustomOperatorProperties):
                     material_name.startswith('NPC') else material_name.split('_')[-1]
                 genshin_material = bpy.data.materials.get(f'miHoYo - Genshin {mesh_body_part_name}')
 
-                if genshin_material:            
+                if genshin_material:
                     material_slot.material = genshin_material
-                elif 'Dress' in mesh_body_part_name or 'Arm' in mesh_body_part_name or 'Cloak' in mesh_body_part_name:
+                elif mesh_body_part_name and ('Dress' in mesh_body_part_name or 'Arm' in mesh_body_part_name or 'Cloak' in mesh_body_part_name):
                     # Xiao is the only character with an Arm material
                     # Dainsleif and Paimon are the only characters with Cloak materials
                     self.report({'INFO'}, 'Dress detected on character model!')
@@ -73,7 +73,7 @@ class GI_OT_GenshinReplaceDefaultMaterials(Operator, CustomOperatorProperties):
                     material_slot.material = bpy.data.materials.get(f'miHoYo - Genshin Body')
                     continue
                 else:
-                    self.report({'WARNING'}, f'Ignoring unknown mesh body part in character model: {mesh_body_part_name}')
+                    self.report({'WARNING'}, f'Ignoring unknown mesh body part in character model: {mesh_body_part_name} / Material: {material_name}')
                     continue
 
                 # Don't need to duplicate multiple Face shader nodes


### PR DESCRIPTION
## 📝Changes related to NPC Support
* Now correctly replaces NPC materials with shader materials
* Now correctly assigns NPC textures to shader materials
* Since NPCs don't have/use shadow ramps, shadow ramps are DISABLED (value set to `0`) on setup if:
  1. The NPC's original material names **does not** have `Avatar` in it (this is how we determine if whether it's an NPC or Playable Character)
  2. No shadow ramp assets are found in the same directory as the other textures

## 📝Changes that are unrelated to NPC Support
* Refactored texture importing
* Add fake users to all shader materials that are imported
* Added some TODOs to look into later


## 🛠️ Misc. Nerdy Notes
NPC textures are named differently then Avatar (playable characters) textures and so there is a class for each. The factory pattern is leveraged to create a `GenshinTextureImporter`. It doesn't matter whether it returns a `GenshinAvatarTextureImporter` or `GenshinNPCTextureImporter` because both of those classes inherit from `GenshinTextureImporter`, which has the `import_textures` method that is called in `GI_OT_GenshinImportTextures.execute()`.

This will allow us to keep the classes open to extension should we need to add another type of texture importing (such as importing textures for Monsters). In simpler terms, we can make a `GenshinMonsterTextureImporter` later on down the line.

These classes could be condensed into one class where we pass the texture identifiers (such as in `GenshinNPCTextureImporter`), but for now, I think it's fine to leave it as is. The trade-off is having the ability to have custom logic for each type of `GenshinTextureImporter` vs. the ability to not have to write "new" code when adding a new type (we could just pass in a dictionary of texture identifiers for each type).

```python
texture_identifiers = {
  "Hair_Diffuse": ["Hair", "Diffuse"],
  "Hair_Lightmap": ["Hair", "Lightmap"]
}
```