### PR TITLE
feat: Set Up ArmTwist Bone Constraints

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,6 @@ If you are downloading an Addon, simply download the zipped file and install the
 
 Thanks to all those who helped answer the questions I had while building out this tool and learning about Blender on Festivity's Discord server.
 <br>
-Special thanks to @Festivity, @TheyCallMeSpy, @Sultana, @M4urlcl0 and @Modder4869!
+:star: Shoutout to @Festivity, @TheyCallMeSpy, @Sultana, @M4urlcl0, @Modder4869 and @Bonny! :star: 
 
 Cheers and Happy Blending!

--- a/setup_wizard/README.md
+++ b/setup_wizard/README.md
@@ -263,6 +263,6 @@ This Setup Wizard should work on all playable characters, but if you do find any
 
 Thanks to all those who helped answer the questions I had while building out this tool and learning about Blender.
 <br>
-Shoutout to @Festivity, @TheyCallMeSpy, @Sultana, @M4urlcl0, @Modder4869 and @Bonny!
+:star: Shoutout to @Festivity, @TheyCallMeSpy, @Sultana, @M4urlcl0, @Modder4869 and @Bonny!
 
 Cheers and Happy Blending

--- a/setup_wizard/README.md
+++ b/setup_wizard/README.md
@@ -6,7 +6,7 @@ The goal of this tool is to streamline the character setup process. Whether it's
 
 **Important**: This tool is intended to be used with Festivity's shaders, found here: https://github.com/festivize/Blender-miHoYo-Shaders
 
-**Compatibility**: This tool has been tested on Blender Version 3.3.0 and attempts to support older versions of Blender, but working functionality is not guaranteed.
+**Compatibility**: This tool has been tested on Blender (and Goo Blender) Version >= 3.3.0 and attempts to support older versions of Blender, but working functionality is not guaranteed.
 
 :star: If this Addon is useful, please be sure to **Star** the repository! :star:
 
@@ -133,6 +133,7 @@ You can disable the cache for any step by unchecking the `Cache Enabled` checkbo
 12. Setup Head Driver
 13. Set Color Management to 'Standard'
 14. Delete EffectMesh
+15. Set Up ArmTwist Bone Constraints
 
 
 ## Steps (Detailed Guide)
@@ -193,18 +194,24 @@ You can disable the cache for any step by unchecking the `Cache Enabled` checkbo
     * Select the JSON files with the material data (Ctrl + Click or Shift + Click).
 10. ~~Fix Mouth Outlines~~ (Legacy, may be return in future releases) - **[Disabled by Default]**
     * This step "fixes" outlines on the mouth (Face) by assigning a Camera to the geometry node and setting Depth Offset. You will likely need to manually change the Depth Offset depending on your scene.
-    * This step may not be needed if you use BetterFBX to import your model (not confirmed).
-11. Delete Specific Objects
-    * This step deletes specific object(s) which is only EffectMesh at this time.
-    * No selection needed.
+    * This step may not be needed if you use BetterFBX to import your model (not confirmed)
 12. Make Character Upright
     * This step will reset the rotation and scale of the character armature and set the character armature to 90 degrees on the x-axis (standing upright).
     * No selection needed.
-13. Set Color Management to 'Standard'
+13. Setup Head Driver
+    * This step will setup the Head Driver constraint so that face shadows work
+    * No selection needed.
+14. Set Color Management to 'Standard'
     * This step will set the Color Management to Standard (normally Filmic)
     * No selection needed.
-14. Setup Head Driver
-    * This step will setup the Head Driver constraint so that face shadows work
+15. Delete Specific Objects
+    * This step deletes specific object(s) which is only EffectMesh at this time.
+    * No selection needed.
+16. Set Up ArmTwist Bone Constraints
+    * This step will create Copy Rotation Bone Constraints on the ArmTwist bones to the Forearm bone (if the ArmTwist bones exist). 
+    * It does this by reorienting the ArmTwist bones so the ArmTwist bone's Tail points towards the Forearm bone's Head.
+    * Afterwards, it creates Copy Rotation Bone Constraints on the ArmTwist bones.
+    * If you do not want these Bone Constraints, you can easily select the bones and turn off the bone constraint.
     * No selection needed.
 </details>
 
@@ -227,6 +234,8 @@ You can disable the cache for any step by unchecking the `Cache Enabled` checkbo
 - [X] UI Setup Wizard Addon
 - [ ] Update Configuration from UI (checkboxes that enable/disable steps)
 - [ ] Batch Character Setup
+- [X] Basic NPC Support
+- [ ] Basic Monster Support
 ### Refactoring
 - [X] Refactor Material Assignment Mapping (externalize/centralize it to one locaiton)
 - [ ] Refactor Import Outline Lightmaps component
@@ -244,20 +253,9 @@ You can disable the cache for any step by unchecking the `Cache Enabled` checkbo
 ![alt text](https://user-images.githubusercontent.com/8632035/183316362-8a47f471-0fa4-4a3d-8e17-ea2c2a9a852e.png)
 
 ## "Tested" Character Models
-The models below should not throw errors when running the Setup Wizard.
-- Amber
-- Alhaitham
-- Collei
-- Dori
-- Hu Tao
-- Kamisato Ayato
-- Keqing
-- Lumine
-- Nahida
-- Nilou
-- Rosaria
-- Tighnari
-- Yelan
+Automated tests are run each release on all playable characters and a small subset of NPC characters.
+<br>
+This Setup Wizard should work on all playable characters, but if you do find any issues or need help, don't hesitate to reach out in the #help channel on Discord or open up an issue in this repository.
 
 #
 
@@ -265,6 +263,6 @@ The models below should not throw errors when running the Setup Wizard.
 
 Thanks to all those who helped answer the questions I had while building out this tool and learning about Blender.
 <br>
-Shoutout to @Festivity, @TheyCallMeSpy, @Sultana, @M4urlcl0 and @Modder4869!
+Shoutout to @Festivity, @TheyCallMeSpy, @Sultana, @M4urlcl0, @Modder4869 and @Bonny!
 
 Cheers and Happy Blending

--- a/setup_wizard/README.md
+++ b/setup_wizard/README.md
@@ -263,6 +263,6 @@ This Setup Wizard should work on all playable characters, but if you do find any
 
 Thanks to all those who helped answer the questions I had while building out this tool and learning about Blender.
 <br>
-:star: Shoutout to @Festivity, @TheyCallMeSpy, @Sultana, @M4urlcl0, @Modder4869 and @Bonny!
+:star: Shoutout to @Festivity, @TheyCallMeSpy, @Sultana, @M4urlcl0, @Modder4869 and @Bonny! :star:
 
 Cheers and Happy Blending

--- a/setup_wizard/README.md
+++ b/setup_wizard/README.md
@@ -261,7 +261,7 @@ This Setup Wizard should work on all playable characters, but if you do find any
 
 ## Credits
 
-Thanks to all those who helped answer the questions I had while building out this tool and learning about Blender.
+Thanks to all those who helped answer the questions I had while building out this tool and learning about Blender on Festivity's Discord server.
 <br>
 :star: Shoutout to @Festivity, @TheyCallMeSpy, @Sultana, @M4urlcl0, @Modder4869 and @Bonny! :star:
 

--- a/setup_wizard/__init__.py
+++ b/setup_wizard/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "Genshin Setup Wizard",
     "author": "Mken",
-    "version": (1, 1, 7),
+    "version": (1, 1, 8),
     "blender": (2, 80, 0),
     "location": "3D View > Sidebar > Genshin Impact Setup Wizard",
     "description": "An addon to streamline the character model setup process when using Festivity's Shaders",

--- a/setup_wizard/config_ui.json
+++ b/setup_wizard/config_ui.json
@@ -14,7 +14,8 @@
             "fix_transformations",
             "setup_head_driver",
             "set_color_management_to_standard",
-            "delete_specific_objects"
+            "delete_specific_objects",
+            "set_up_armtwist_bone_constraints"
         ],
         "GENSHIN_OT_setup_wizard_ui_no_outlines": [
             "IMPORTANT_PLACEHOLDER_VALUE_KEEP_INDEX_ABOVE_0_setup_wizard_ui",
@@ -26,7 +27,8 @@
             "fix_transformations",
             "setup_head_driver",
             "set_color_management_to_standard",
-            "delete_specific_objects"
+            "delete_specific_objects",
+            "set_up_armtwist_bone_constraints"
         ],
         "GENSHIN_OT_set_up_character": [
             "IMPORTANT_PLACEHOLDER_VALUE_KEEP_INDEX_ABOVE_0_set_up_character",
@@ -51,7 +53,8 @@
             "fix_transformations",
             "setup_head_driver",
             "set_color_management_to_standard",
-            "delete_specific_objects"
+            "delete_specific_objects",
+            "set_up_armtwist_bone_constraints"
         ]
     }
 }

--- a/setup_wizard/domain/texture_importers.py
+++ b/setup_wizard/domain/texture_importers.py
@@ -36,6 +36,12 @@ class GenshinTextureImporter:
                 return False
         return True
 
+    def is_texture_identifiers_in_files(self, texture_identifiers, files):
+        for file in files:
+            if self.is_texture_identifiers_in_texture_name(texture_identifiers, file):
+                return True
+        return False
+
     def set_diffuse_texture(self, type: TextureType, material, img):
         material.node_tree.nodes[f'{type.value}_Diffuse_UV0'].image = img
         material.node_tree.nodes[f'{type.value}_Diffuse_UV1'].image = img
@@ -148,7 +154,7 @@ class GenshinAvatarTextureImporter(GenshinTextureImporter):
                 body_material = bpy.data.materials.get('miHoYo - Genshin Body')
 
                 # Implement the texture in the correct node
-                print(f'Importing texture {file}')
+                print(f'Importing texture {file} using {self.__class__.__name__}')
                 if "Hair_Diffuse" in file and "Eff" not in file:
                     self.set_diffuse_texture(TextureType.HAIR, hair_material, img)
                 elif "Hair_Lightmap" in file:
@@ -194,7 +200,7 @@ class GenshinNPCTextureImporter(GenshinTextureImporter):
                 body_material = bpy.data.materials.get('miHoYo - Genshin Body')
 
                 # Implement the texture in the correct node
-                print(f'Importing texture {file}')
+                print(f'Importing texture {file} using {self.__class__.__name__}')
                 if self.is_texture_identifiers_in_texture_name(['Hair', 'Diffuse'], file) and \
                     not self.is_texture_identifiers_in_texture_name(['Eff'], file):
                     self.set_diffuse_texture(TextureType.HAIR, hair_material, img)
@@ -227,8 +233,12 @@ class GenshinNPCTextureImporter(GenshinTextureImporter):
                 elif self.is_texture_identifiers_in_texture_name(['Face', 'Diffuse'], file):
                     self.set_face_diffuse_texture(face_material, img)
 
-                elif self.is_texture_identifiers_in_texture_name(['NPC', 'Face', 'Lightmap'], file):
-                    self.set_face_shadow_texture(face_material, img)  # Not a typo (set face shadow as NPC lightmap)
+                elif self.is_texture_identifiers_in_texture_name(['Face', 'Shadow'], file) or \
+                    (self.is_texture_identifiers_in_texture_name(['NPC', 'Face', 'Lightmap'], file) and
+                        not self.is_texture_identifiers_in_files(['Face', 'Shadow'], files)):
+                    # If Face Shadow exists, use that texture
+                    # If Face Shadow does not exist in this folder, use "Face Lightmap" (actually an NPC Face Shadow texture)
+                    self.set_face_shadow_texture(face_material, img)
 
                 elif self.is_texture_identifiers_in_texture_name(['Face', 'Lightmap'], file):
                     self.set_face_lightmap_texture(img)

--- a/setup_wizard/genshin_import_outline_lightmaps.py
+++ b/setup_wizard/genshin_import_outline_lightmaps.py
@@ -58,8 +58,11 @@ class GI_OT_GenshinImportOutlineLightmaps(Operator, ImportHelper, CustomOperator
 
             for outline_material in outline_materials:
                 body_part_material_name = outline_material.name.split(' ')[-2]  # ex. 'miHoYo - Genshin Hair Outlines'
-                original_material_name = [material for material in bpy.data.materials if material.name.endswith(f'Mat_{body_part_material_name}')][0]  # from original model
-                actual_material_part_name = get_actual_material_name_for_dress(original_material_name.name)
+                original_mesh_material = \
+                    [material for material in bpy.data.materials if material.name.startswith('NPC') and body_part_material_name in material.name][0] if \
+                    [material for material in bpy.data.materials if material.name.startswith('NPC')] else \
+                    [material for material in bpy.data.materials if material.name.endswith(f'Mat_{body_part_material_name}')][0]
+                actual_material_part_name = get_actual_material_name_for_dress(original_mesh_material.name)
 
                 if 'Face' not in actual_material_part_name and 'Face' not in body_part_material_name:
                     self.assign_lightmap_texture(character_model_folder_file_path, lightmap_files, body_part_material_name, actual_material_part_name)

--- a/setup_wizard/genshin_setup_wizard.py
+++ b/setup_wizard/genshin_setup_wizard.py
@@ -111,6 +111,7 @@ def setup_dependencies():
         setup_wizard.set_up_head_driver.GI_OT_SetUpHeadDriver,
         setup_wizard.misc_operations.GI_OT_SetColorManagementToStandard,
         setup_wizard.misc_operations.GI_OT_DeleteSpecificObjects,
+        setup_wizard.misc_operations.GI_OT_SetUpArmTwistBoneConstraints,
         setup_wizard.genshin_gran_turismo_tonemapper_setup.GI_OT_GenshinGranTurismoTonemapperSetup,
         setup_wizard.change_bpy_context.GI_OT_Change_BPY_Context,
     ]:
@@ -134,7 +135,8 @@ def unregister():
     from setup_wizard.genshin_import_material_data import GI_OT_GenshinImportMaterialData
     from setup_wizard.misc_final_steps import GI_OT_FixTransformations
     from setup_wizard.set_up_head_driver import GI_OT_SetUpHeadDriver
-    from setup_wizard.misc_operations import GI_OT_SetColorManagementToStandard, GI_OT_DeleteSpecificObjects
+    from setup_wizard.misc_operations import GI_OT_SetColorManagementToStandard, GI_OT_DeleteSpecificObjects, \
+        GI_OT_SetUpArmTwistBoneConstraints
     from setup_wizard.genshin_gran_turismo_tonemapper_setup import GI_OT_GenshinGranTurismoTonemapperSetup
     from setup_wizard.change_bpy_context import GI_OT_Change_BPY_Context
 
@@ -152,6 +154,7 @@ def unregister():
         GI_OT_SetUpHeadDriver,
         GI_OT_SetColorManagementToStandard,
         GI_OT_DeleteSpecificObjects,
+        GI_OT_SetUpArmTwistBoneConstraints,
         GI_OT_GenshinGranTurismoTonemapperSetup,
         GI_OT_Change_BPY_Context,
     ]:

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -183,6 +183,8 @@ class ComponentFunctionFactory:
             return bpy.ops.genshin.set_color_management_to_standard
         elif component_name == 'setup_head_driver':
             return bpy.ops.genshin.setup_head_driver
+        elif component_name == 'set_up_armtwist_bone_constraints':
+            return bpy.ops.genshin.set_up_armtwist_bone_constraints
         elif component_name == 'clear_cache_operator':
             return bpy.ops.genshin.clear_cache_operator
         elif component_name == 'change_bpy_context':

--- a/setup_wizard/misc_operations.py
+++ b/setup_wizard/misc_operations.py
@@ -99,7 +99,11 @@ class GI_OT_SetUpArmTwistBoneConstraints(Operator, CustomOperatorProperties):
         for bone_name in bone_names:
             bone = armature.data.edit_bones.get(bone_name)
             target_bone = armature.data.edit_bones.get(target_bone_name)
+
+            original_bone_length = bone.length
             bone.tail = target_bone.head
+            bone.length = original_bone_length
+
         bpy.ops.object.mode_set(mode='OBJECT')
 
     def set_up_armtwist_bone_constraint(self, armature, bone_name, subtarget_bone_name, influence):

--- a/setup_wizard/misc_operations.py
+++ b/setup_wizard/misc_operations.py
@@ -49,7 +49,73 @@ class GI_OT_DeleteSpecificObjects(Operator, CustomOperatorProperties):
         return {'FINISHED'}
 
 
+class GI_OT_SetUpArmTwistBoneConstraints(Operator, CustomOperatorProperties):
+    '''Sets Up ArmTwist Bone Constraints'''
+    bl_idname = 'genshin.set_up_armtwist_bone_constraints'
+    bl_label = 'Genshin: Set Up ArmTwist Bone Constraints'
+
+    def execute(self, context):
+        armature =  [object for object in bpy.data.objects if object.type == 'ARMATURE'][0]
+        armature_bones = armature.pose.bones
+
+        bpy.context.view_layer.objects.active = armature
+        bpy.ops.object.mode_set(mode='EDIT')
+
+        upper_arm_bone = armature.data.edit_bones.get('Bip001 R Forearm')
+        twist_bone = armature.data.edit_bones.get('+UpperArmTwist R A01')
+        twist_bone.tail = upper_arm_bone.head
+
+        twist_bone = armature.data.edit_bones.get('+UpperArmTwist R A02')
+        twist_bone.tail = upper_arm_bone.head
+
+        bpy.ops.object.mode_set(mode='OBJECT')
+
+        twist_bone = armature_bones.get('+UpperArmTwist R A01')
+        copy_rotation_constraint = twist_bone.constraints.new('COPY_ROTATION')
+        copy_rotation_constraint.target = armature
+        copy_rotation_constraint.subtarget = 'Bip001 R Forearm'
+
+        copy_rotation_constraint.use_x = False
+        copy_rotation_constraint.use_z = False
+
+        copy_rotation_constraint.target_space = 'LOCAL'
+        copy_rotation_constraint.owner_space = 'LOCAL'
+
+        copy_rotation_constraint.influence = 0.35
+
+        twist_bone = armature_bones.get('+UpperArmTwist R A02')
+        copy_rotation_constraint = twist_bone.constraints.new('COPY_ROTATION')
+        copy_rotation_constraint.target = armature
+        copy_rotation_constraint.subtarget = 'Bip001 R Forearm'
+
+        copy_rotation_constraint.use_x = False
+        copy_rotation_constraint.use_z = False
+
+        copy_rotation_constraint.target_space = 'LOCAL'
+        copy_rotation_constraint.owner_space = 'LOCAL'
+
+        copy_rotation_constraint.influence = 0.65
+
+        print(twist_bone)
+
+        if self.next_step_idx:
+            NextStepInvoker().invoke(
+                self.next_step_idx, 
+                self.invoker_type, 
+                high_level_step_name=self.high_level_step_name
+            )
+        return {'FINISHED'}
+
+
+    def reorient_armtwist_bones(self):
+        pass
+
+    def set_up_bone_constarint(self):
+        pass
+
+
 register, unregister = bpy.utils.register_classes_factory([
     GI_OT_SetColorManagementToStandard,
-    GI_OT_DeleteSpecificObjects
+    GI_OT_DeleteSpecificObjects,
+    GI_OT_SetUpArmTwistBoneConstraints,
 ])

--- a/setup_wizard/misc_operations.py
+++ b/setup_wizard/misc_operations.py
@@ -100,9 +100,10 @@ class GI_OT_SetUpArmTwistBoneConstraints(Operator, CustomOperatorProperties):
             bone = armature.data.edit_bones.get(bone_name)
             target_bone = armature.data.edit_bones.get(target_bone_name)
 
-            original_bone_length = bone.length
-            bone.tail = target_bone.head
-            bone.length = original_bone_length
+            if bone and target_bone:
+                original_bone_length = bone.length
+                bone.tail = target_bone.head
+                bone.length = original_bone_length
 
         bpy.ops.object.mode_set(mode='OBJECT')
 
@@ -110,16 +111,16 @@ class GI_OT_SetUpArmTwistBoneConstraints(Operator, CustomOperatorProperties):
         armature_bones = armature.pose.bones
         twist_bone = armature_bones.get(bone_name)
 
-        copy_rotation_constraint = twist_bone.constraints.new('COPY_ROTATION')
-        copy_rotation_constraint.target = armature
-        copy_rotation_constraint.subtarget = subtarget_bone_name
-        copy_rotation_constraint.use_x = False
-        copy_rotation_constraint.use_z = False
-        copy_rotation_constraint.target_space = 'LOCAL'
-        copy_rotation_constraint.owner_space = 'LOCAL'
-        copy_rotation_constraint.influence = influence
-
-        return copy_rotation_constraint
+        if twist_bone and subtarget_bone_name:
+            copy_rotation_constraint = twist_bone.constraints.new('COPY_ROTATION')
+            copy_rotation_constraint.target = armature
+            copy_rotation_constraint.subtarget = subtarget_bone_name
+            copy_rotation_constraint.use_x = False
+            copy_rotation_constraint.use_z = False
+            copy_rotation_constraint.target_space = 'LOCAL'
+            copy_rotation_constraint.owner_space = 'LOCAL'
+            copy_rotation_constraint.influence = influence
+            return copy_rotation_constraint
 
 
 register, unregister = bpy.utils.register_classes_factory([

--- a/setup_wizard/tests/test_setup_character.py
+++ b/setup_wizard/tests/test_setup_character.py
@@ -73,6 +73,7 @@ def setup_character(config, character_name, character_folder_file_path):
             TestOperatorExecutioner('setup_head_driver'),
             TestOperatorExecutioner('set_color_management_to_standard'),
             TestOperatorExecutioner('delete_specific_objects'),
+            TestOperatorExecutioner('set_up_armtwist_bone_constraints'),
         ]
 
         for operator in operators:

--- a/setup_wizard/tests/test_setup_character.py
+++ b/setup_wizard/tests/test_setup_character.py
@@ -24,6 +24,25 @@ logger = logging.getLogger(__name__)
 
 def setup_character(config, character_name, character_folder_file_path):
     logger.info(f'Starting test for {character_name}')
+    logger.info(f'Emptying scene...')
+
+    default_objects_to_delete = ['Cube', 'Light', 'Camera']
+
+    for object_to_delete in default_objects_to_delete:
+        object = bpy.context.scene.objects.get(object_to_delete)
+        if object:
+            object_name = object.name  # necessary to create because we lose the reference after deletion
+            logger.info(f'Deleting {object_name}')
+            bpy.data.objects.remove(object)
+            logger.info(f'Deleted {object_name}')
+
+    logger.info(f'Preparing scene...')
+    default_collection = bpy.data.collections.get('Collection')
+    if default_collection:
+        logger.info(f'Renaming {default_collection.name} to {character_name}...')
+        default_collection.name = character_name
+        logger.info(f'Successfully renamed Collection to: {bpy.data.collections.get(character_name).name}')
+
     logger.info(f'{config.get("metadata")}')
 
     if config.get('metadata').get('betterfbx_enabled'):
@@ -87,6 +106,25 @@ def setup_character(config, character_name, character_folder_file_path):
         logger.error(ex)
         logger.error(f'Failed test for {arg_character_name}')
         raise ex  # If it errors out it will still quit blender
+    finally:
+        logger.info(f'Preparing file for {character_name}')
+        logger.info('Setting Transform Mode to "XYZ Euler"...')
+        character_armature = [object for object in bpy.data.objects if object.type == 'ARMATURE'][0]
+        character_armature.rotation_mode = 'XYZ'
+        character_armature.animation_data_clear()  # some characters have animation data, clear it
+        logger.info('Successfully set to "XYZ Euler"')
+
+        logger.info('Packing files...')
+        try:
+            bpy.ops.file.pack_all()
+        except RuntimeError as e:
+            logger.warning(e)
+        logger.info('Successfully packed files')
+
+        filename = f'{character_name}.blend'
+        logger.info(f'Saving file for {character_name} as: {filename}...')
+        bpy.ops.wm.save_as_mainfile(filepath=f'{os.path.abspath(arg_logs_directory_path)}/{filename}')
+        logger.info(f'Saved file for {character_name} as: {filename}')
     bpy.ops.wm.quit_blender()
 
 

--- a/setup_wizard/tests/test_setup_character.py
+++ b/setup_wizard/tests/test_setup_character.py
@@ -107,24 +107,25 @@ def setup_character(config, character_name, character_folder_file_path):
         logger.error(f'Failed test for {arg_character_name}')
         raise ex  # If it errors out it will still quit blender
     finally:
-        logger.info(f'Preparing file for {character_name}')
-        logger.info('Setting Transform Mode to "XYZ Euler"...')
-        character_armature = [object for object in bpy.data.objects if object.type == 'ARMATURE'][0]
-        character_armature.rotation_mode = 'XYZ'
-        character_armature.animation_data_clear()  # some characters have animation data, clear it
-        logger.info('Successfully set to "XYZ Euler"')
+        if config.get('metadata').get('save_file'):
+            logger.info(f'Preparing file for {character_name}')
+            logger.info('Setting Transform Mode to "XYZ Euler"...')
+            character_armature = [object for object in bpy.data.objects if object.type == 'ARMATURE'][0]
+            character_armature.rotation_mode = 'XYZ'
+            character_armature.animation_data_clear()  # some characters have animation data, clear it
+            logger.info('Successfully set to "XYZ Euler"')
 
-        logger.info('Packing files...')
-        try:
-            bpy.ops.file.pack_all()
-        except RuntimeError as e:
-            logger.warning(e)
-        logger.info('Successfully packed files')
+            logger.info('Packing files...')
+            try:
+                bpy.ops.file.pack_all()
+            except RuntimeError as e:
+                logger.warning(e)
+            logger.info('Successfully packed files')
 
-        filename = f'{character_name}.blend'
-        logger.info(f'Saving file for {character_name} as: {filename}...')
-        bpy.ops.wm.save_as_mainfile(filepath=f'{os.path.abspath(arg_logs_directory_path)}/{filename}')
-        logger.info(f'Saved file for {character_name} as: {filename}')
+            filename = f'{character_name}.blend'
+            logger.info(f'Saving file for {character_name} as: {filename}...')
+            bpy.ops.wm.save_as_mainfile(filepath=f'{os.path.abspath(arg_logs_directory_path)}/{filename}')
+            logger.info(f'Saved file for {character_name} as: {filename}')
     bpy.ops.wm.quit_blender()
 
 

--- a/setup_wizard/ui_setup_wizard_menu.py
+++ b/setup_wizard/ui_setup_wizard_menu.py
@@ -233,6 +233,12 @@ class GI_PT_UI_Finish_Setup_Menu(Panel):
             'Delete EffectMesh',
             'TRASH'
         )
+        OperatorFactory.create(
+            sub_layout,
+            'genshin.set_up_armtwist_bone_constraints',
+            'Set Up ArmTwist Bone Constraints',
+            'CONSTRAINT_BONE'
+        )
 
 
 class GI_PT_UI_Gran_Turismo_UI_Layout(Panel):


### PR DESCRIPTION
### ⭐  Features
* Reorients ArmTwist bones towards the Forearm Head (A01 and A02, if they exist)
* Sets up Copy Rotation bone constraints on the ArmTwist bones

### 🛠️ Fixes
* Fix Face Shadow/Face Lightmap textures not being imported correctly for a certain traveling companion
* Setup Wizard for NPCs breaks when trying to import outline diffuse/lightmap for Outlines

### 📝 Chores
* Update README
* Bump Addon Version
* Minor updates to automated tests