### PR TITLE
feat: Character Setup Wizard basic NPC and Monster support

### DIFF
--- a/setup_wizard/__init__.py
+++ b/setup_wizard/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "HoYoverse Setup Wizard",
     "author": "Mken",
-    "version": (1, 2, 1),
+    "version": (1, 2, 2),
     "blender": (2, 80, 0),
     "location": "3D View > Sidebar > Genshin Impact / Honkai Star Rail",
     "description": "An addon to streamline the character model setup process when using Festivity or Nya222's Shaders",

--- a/setup_wizard/domain/character_types.py
+++ b/setup_wizard/domain/character_types.py
@@ -12,3 +12,4 @@ class CharacterType(Enum):
     MONSTER = auto()
     NPC = auto()
     UNKNOWN = auto()
+    GI_EQUIPMENT = auto()

--- a/setup_wizard/domain/character_types.py
+++ b/setup_wizard/domain/character_types.py
@@ -1,0 +1,14 @@
+from enum import Enum, auto
+
+'''
+It's important to separate this out into its own class because import_order uses GameType and 
+Setup Wizard uses GameType and import_order.
+
+This would result in a circular dependency if it existed in import_order or a Setup Wizard class.
+'''
+class CharacterType(Enum):
+    AVATAR = auto()
+    HSR_AVATAR = auto()
+    MONSTER = auto()
+    NPC = auto()
+    UNKNOWN = auto()

--- a/setup_wizard/domain/outline_material_data.py
+++ b/setup_wizard/domain/outline_material_data.py
@@ -1,0 +1,9 @@
+# Author: michael-gh1
+
+from bpy.types import Material
+
+
+class OutlineMaterialGroup:
+    def __init__(self, material: Material, outlines_material: Material):
+        self.material = material
+        self.outlines_material = outlines_material

--- a/setup_wizard/domain/shader_configurator.py
+++ b/setup_wizard/domain/shader_configurator.py
@@ -7,15 +7,16 @@ class ShaderConfigurator:
 
     def update_shader_value(self, materials, node_name, input_name, value):
         for material in materials:
-            if material:
-                internal_node_name = self.v2_node_name_mapping.get(node_name) if \
-                    self.v2_node_name_mapping.get(node_name) else self.v1_node_name_mapping.get(node_name)
+            if not material:
+                continue
+            internal_node_name = self.v2_node_name_mapping.get(node_name) if \
+                self.v2_node_name_mapping.get(node_name) else self.v1_node_name_mapping.get(node_name)
 
-                shader_node = material.node_tree.nodes.get(internal_node_name)
-                shader_node_inputs = shader_node.inputs if shader_node else None
+            shader_node = material.node_tree.nodes.get(internal_node_name)
+            shader_node_inputs = shader_node.inputs if shader_node else None
 
-                if shader_node_inputs:
-                    shader_node_input = shader_node_inputs.get(input_name)
+            if shader_node_inputs:
+                shader_node_input = shader_node_inputs.get(input_name)
 
-                    if shader_node_input:
-                        shader_node_input.default_value = value
+                if shader_node_input:
+                    shader_node_input.default_value = value

--- a/setup_wizard/domain/shader_configurator.py
+++ b/setup_wizard/domain/shader_configurator.py
@@ -7,14 +7,15 @@ class ShaderConfigurator:
 
     def update_shader_value(self, materials, node_name, input_name, value):
         for material in materials:
-            internal_node_name = self.v2_node_name_mapping.get(node_name) if \
-                self.v2_node_name_mapping.get(node_name) else self.v1_node_name_mapping.get(node_name)
+            if material:
+                internal_node_name = self.v2_node_name_mapping.get(node_name) if \
+                    self.v2_node_name_mapping.get(node_name) else self.v1_node_name_mapping.get(node_name)
 
-            shader_node = material.node_tree.nodes.get(internal_node_name)
-            shader_node_inputs = shader_node.inputs if shader_node else None
+                shader_node = material.node_tree.nodes.get(internal_node_name)
+                shader_node_inputs = shader_node.inputs if shader_node else None
 
-            if shader_node_inputs:
-                shader_node_input = shader_node_inputs.get(input_name)
+                if shader_node_inputs:
+                    shader_node_input = shader_node_inputs.get(input_name)
 
-                if shader_node_input:
-                    shader_node_input.default_value = value
+                    if shader_node_input:
+                        shader_node_input.default_value = value

--- a/setup_wizard/exceptions.py
+++ b/setup_wizard/exceptions.py
@@ -6,3 +6,8 @@ class UnsupportedMaterialDataJsonFormatException(Exception):
             'Unsupported Material Data Json format detected. ' \
                 f'Supported Material Data Json Formats: {parsers}'
         super().__init__(message)
+
+
+class UserInputException(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -57,7 +57,7 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
     def execute(self, context):
         selected_material = context.scene.setup_wizard_selected_material_for_material_data_import
 
-        game_material_data_importer = GameMaterialDataImporterFactory.create(self.game_type, self, context, selected_material)
+        game_material_data_importer = GameMaterialDataImporterFactory.create(self.game_type, self, context)
         game_material_data_importer.import_material_data()
 
         self.report({'INFO'}, 'Imported material data')

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -65,12 +65,13 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
         game_material_data_importer.import_material_data()
 
         self.report({'INFO'}, 'Imported material data')
-        NextStepInvoker().invoke(
-            self.next_step_idx, 
-            self.invoker_type, 
-            high_level_step_name=self.high_level_step_name,
-            game_type=self.game_type,
-        )
+        if self.filepath or self.files:
+            NextStepInvoker().invoke(
+                self.next_step_idx, 
+                self.invoker_type, 
+                high_level_step_name=self.high_level_step_name,
+                game_type=self.game_type,
+            )
         super().clear_custom_properties()
         return {'FINISHED'}
 

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -7,6 +7,7 @@ import bpy
 from bpy_extras.io_utils import ImportHelper
 from bpy.props import StringProperty, CollectionProperty, PointerProperty
 from bpy.types import Operator, PropertyGroup
+from setup_wizard.domain.outline_material_data import OutlineMaterialGroup
 
 from setup_wizard.import_order import NextStepInvoker
 from setup_wizard.material_data_import_setup.game_material_data_importers import GameMaterialDataImporterFactory
@@ -55,9 +56,12 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
     ]
 
     def execute(self, context):
-        selected_material = context.scene.setup_wizard_selected_material_for_material_data_import
+        selected_material = context.scene.setup_wizard_material_for_material_data_import
+        outlines_material = context.scene.setup_wizard_outlines_material_for_material_data_import
 
-        game_material_data_importer = GameMaterialDataImporterFactory.create(self.game_type, self, context)
+        outline_material_group: OutlineMaterialGroup = OutlineMaterialGroup(selected_material, outlines_material)
+
+        game_material_data_importer = GameMaterialDataImporterFactory.create(self.game_type, self, context, outline_material_group)
         game_material_data_importer.import_material_data()
 
         self.report({'INFO'}, 'Imported material data')

--- a/setup_wizard/genshin_import_material_data.py
+++ b/setup_wizard/genshin_import_material_data.py
@@ -5,7 +5,7 @@ import bpy
 # ImportHelper is a helper class, defines filename and
 # invoke() function which calls the file selector.
 from bpy_extras.io_utils import ImportHelper
-from bpy.props import StringProperty, CollectionProperty
+from bpy.props import StringProperty, CollectionProperty, PointerProperty
 from bpy.types import Operator, PropertyGroup
 
 from setup_wizard.import_order import NextStepInvoker
@@ -20,6 +20,16 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
     """Select the Character Material Data Json Files for Outlines"""
     bl_idname = "genshin.import_material_data"  # important since its how we chain file dialogs
     bl_label = "Genshin: Select Material Json Data Files"
+
+    bpy.types.Scene.setup_wizard_material_for_material_data_import = PointerProperty(
+        name='Target Material',
+        type=bpy.types.Material
+    )
+
+    bpy.types.Scene.setup_wizard_outlines_material_for_material_data_import = PointerProperty(
+        name='Outlines Material',
+        type=bpy.types.Material
+    )
 
     # ImportHelper mixin class uses this
     filename_ext = "*.*"
@@ -45,7 +55,9 @@ class GI_OT_GenshinImportMaterialData(Operator, ImportHelper, CustomOperatorProp
     ]
 
     def execute(self, context):
-        game_material_data_importer = GameMaterialDataImporterFactory.create(self.game_type, self, context)
+        selected_material = context.scene.setup_wizard_selected_material_for_material_data_import
+
+        game_material_data_importer = GameMaterialDataImporterFactory.create(self.game_type, self, context, selected_material)
         game_material_data_importer.import_material_data()
 
         self.report({'INFO'}, 'Imported material data')

--- a/setup_wizard/genshin_replace_default_materials.py
+++ b/setup_wizard/genshin_replace_default_materials.py
@@ -6,7 +6,6 @@ from bpy.props import StringProperty
 from bpy.types import Operator
 
 from setup_wizard.import_order import NextStepInvoker
-from setup_wizard.import_order import get_actual_material_name_for_dress
 from setup_wizard.setup_wizard_operator_base_classes import CustomOperatorProperties
 from setup_wizard.replace_default_materials_setup.default_material_replacer_service import DefaultMaterialReplacerService
 from setup_wizard.replace_default_materials_setup.game_default_material_replacers import GameDefaultMaterialReplacerFactory

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -186,9 +186,16 @@ def clear_cache(game_type: str):
         f.write(json_string)
 
 
-
+'''
+This method is a real mess, be prepared to spend some time if you're working with a Dress material!
+There are a few issues that cause this:
+1. AVATARs and NPCs/MONSTERs have different logic
+2. Dress materials can be Body or Hair for AVATARs
+3. Dress materials are only Body (to be confirmed) for NPCs/MONSTERs
+'''
 def get_actual_material_name_for_dress(material_name, character_type='AVATAR'):
-    if character_type == 'AVATAR':
+    # must check string instead of enum until this is moved out of import_order.py due to circular dependency
+    if character_type == 'AVATAR' or character_type == 'HSR_AVATAR':
         for material in bpy.data.materials:
             if material_name in material.name:
                 try:
@@ -206,15 +213,13 @@ def get_actual_material_name_for_dress(material_name, character_type='AVATAR'):
                     actual_material_name = material_name.split('_')[-1]
                     actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
                     print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
-                except KeyError:
-                    # NPC or Monster w/ Dress?
-                    actual_material_name = material_name.split(' ')[-1]
-                    actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
-                    print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
-                return actual_material_name
     else:
-        # NPC or Monster?
-        actual_material_name = material_name.split('_')[-2]
+        # NPC/Monster?
+        # ex. 'XXXX_Dress_Mat' or 'XXXX - Genshin Dress'
+        is_shader_dress_material = 'Genshin Dress' in material_name  # 'XXXX - Genshin Dress'
+
+        # is it the shader's Dress material? or are we checking the original material's name?
+        actual_material_name = material_name.split(' ')[-1] if is_shader_dress_material else material_name.split('_')[-2]
         actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
         print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
         return actual_material_name

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -219,7 +219,7 @@ def get_actual_material_name_for_dress(material_name, character_type='AVATAR'):
         is_shader_dress_material = 'Genshin Dress' in material_name  # 'XXXX - Genshin Dress'
 
         # is it the shader's Dress material? or are we checking the original material's name?
-        actual_material_name = material_name.split(' ')[-1] if is_shader_dress_material else material_name.split('_')[-2]
+        actual_material_name = material_name.split(' ')[-1] if is_shader_dress_material else material_name.split('_')[-2] if material_name.split('_')[-2] != 'Mat' else material_name.split('_')[-1]
         actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
         print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
         return actual_material_name

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -200,7 +200,6 @@ def get_actual_material_name_for_dress(material_name, character_type='AVATAR'):
             if material_name in material.name:
                 try:
                     # ex. 'Avatar_Lady_Pole_Rosaria_Tex_Body_Diffuse.png'
-                    print(material_name)
                     base_color_texture_image_name = material.node_tree.nodes['Principled BSDF'].inputs['Base Color'].links[0].from_node.image.name_full
                     actual_material_name = base_color_texture_image_name.split('_')[-2]
                     actual_material_name = \

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -187,24 +187,37 @@ def clear_cache(game_type: str):
 
 
 
-def get_actual_material_name_for_dress(material_name):
-    for material in bpy.data.materials:
-        if material_name in material.name:
-            try:
-                # ex. 'Avatar_Lady_Pole_Rosaria_Tex_Body_Diffuse.png'
-                base_color_texture_image_name = material.node_tree.nodes['Principled BSDF'].inputs['Base Color'].links[0].from_node.image.name_full
-                actual_material_name = base_color_texture_image_name.split('_')[-2]
-                actual_material_name = \
-                    actual_material_name if actual_material_name == 'Hair' or actual_material_name == 'Body' \
-                        else 'Hair' if 'Hair' in base_color_texture_image_name \
-                            else 'Body' if 'Body' in base_color_texture_image_name \
-                                else actual_material_name  # fallback method to get mat name
-            except IndexError:
-                # ex. 'Diffuse Texture.001'
-                actual_material_name = material_name.split('_')[-1]
-                actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
-                print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
-            return actual_material_name
+def get_actual_material_name_for_dress(material_name, character_type='AVATAR'):
+    if character_type == 'AVATAR':
+        for material in bpy.data.materials:
+            if material_name in material.name:
+                try:
+                    # ex. 'Avatar_Lady_Pole_Rosaria_Tex_Body_Diffuse.png'
+                    print(material_name)
+                    base_color_texture_image_name = material.node_tree.nodes['Principled BSDF'].inputs['Base Color'].links[0].from_node.image.name_full
+                    actual_material_name = base_color_texture_image_name.split('_')[-2]
+                    actual_material_name = \
+                        actual_material_name if actual_material_name == 'Hair' or actual_material_name == 'Body' \
+                            else 'Hair' if 'Hair' in base_color_texture_image_name \
+                                else 'Body' if 'Body' in base_color_texture_image_name \
+                                    else actual_material_name  # fallback method to get mat name
+                except IndexError:
+                    # ex. 'Diffuse Texture.001'
+                    actual_material_name = material_name.split('_')[-1]
+                    actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
+                    print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
+                except KeyError:
+                    # NPC or Monster w/ Dress?
+                    actual_material_name = material_name.split(' ')[-1]
+                    actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
+                    print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
+                return actual_material_name
+    else:
+        # NPC or Monster?
+        actual_material_name = material_name.split('_')[-2]
+        actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
+        print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
+        return actual_material_name
 
 
 class ComponentFunctionFactory:

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -212,6 +212,7 @@ def get_actual_material_name_for_dress(material_name, character_type='AVATAR'):
                     actual_material_name = material_name.split('_')[-1]
                     actual_material_name = actual_material_name if actual_material_name != 'Dress' else 'Body'  # if mat name is 'body' or 'hair' use that, else fallback to 'body'
                     print(f'WARNING: Fallback to applying "{actual_material_name}" onto "{material_name}". Image name is not parseable for: {material_name}')
+                return actual_material_name
     else:
         # NPC/Monster?
         # ex. 'XXXX_Dress_Mat' or 'XXXX - Genshin Dress'

--- a/setup_wizard/material_data_import_setup/game_material_data_importers.py
+++ b/setup_wizard/material_data_import_setup/game_material_data_importers.py
@@ -13,7 +13,7 @@ from setup_wizard.domain.outline_material_data import OutlineMaterialGroup
 from setup_wizard.exceptions import UnsupportedMaterialDataJsonFormatException, UserInputException
 from setup_wizard.material_data_import_setup.material_data_applier import MaterialDataApplier, MaterialDataAppliersFactory
 from setup_wizard.parsers.material_data_json_parsers import HoyoStudioMaterialDataJsonParser, MaterialDataJsonParser, UABEMaterialDataJsonParser
-from setup_wizard.utils.genshin_body_part_deducer import get_monster_body_part_name
+from setup_wizard.utils.genshin_body_part_deducer import get_monster_body_part_name, get_npc_mesh_body_part_name
 
 class GameMaterialDataImporter(ABC):
     @abstractmethod
@@ -97,6 +97,9 @@ class GenshinImpactMaterialDataImporter(GameMaterialDataImporter):
                 expected_body_part_name = PurePosixPath(file.name).stem.split('_')[-2]
                 body_part = get_monster_body_part_name(PurePosixPath(file.name).stem.split('_')[-2]) if expected_body_part_name != 'Mat' else get_monster_body_part_name(PurePosixPath(file.name).stem.split('_')[-1])
                 character_type = CharacterType.MONSTER
+            elif 'NPC' in file.name:
+                body_part = get_npc_mesh_body_part_name(PurePosixPath(file.name).stem)
+                character_type = CharacterType.NPC
             elif 'Equip' in file.name:
                 body_part = 'Body'
                 character_type = CharacterType.GI_EQUIPMENT

--- a/setup_wizard/material_data_import_setup/game_material_data_importers.py
+++ b/setup_wizard/material_data_import_setup/game_material_data_importers.py
@@ -94,7 +94,8 @@ class GenshinImpactMaterialDataImporter(GameMaterialDataImporter):
             body_part = None
 
             if 'Monster' in file.name:
-                body_part = get_monster_body_part_name(PurePosixPath(file.name).stem.split('_')[-2])
+                expected_body_part_name = PurePosixPath(file.name).stem.split('_')[-2]
+                body_part = get_monster_body_part_name(PurePosixPath(file.name).stem.split('_')[-2]) if expected_body_part_name != 'Mat' else get_monster_body_part_name(PurePosixPath(file.name).stem.split('_')[-1])
                 character_type = CharacterType.MONSTER
             elif 'Equip' in file.name:
                 body_part = 'Body'

--- a/setup_wizard/material_data_import_setup/game_material_data_importers.py
+++ b/setup_wizard/material_data_import_setup/game_material_data_importers.py
@@ -81,7 +81,11 @@ class GenshinImpactMaterialDataImporter(GameMaterialDataImporter):
             return {'FINISHED'}
 
         for file in self.blender_operator.files:
-            body_part = PurePosixPath(file.name).stem.split('_')[-1]
+            body_part = None
+            if 'Monster' in file.name:
+                body_part = PurePosixPath(file.name).stem.split('_')[-2]
+            else:
+                body_part = PurePosixPath(file.name).stem.split('_')[-1]
 
             fp = open(f'{directory_file_path}/{file.name}')
             json_material_data = json.load(fp)

--- a/setup_wizard/material_data_import_setup/material_data_applier.py
+++ b/setup_wizard/material_data_import_setup/material_data_applier.py
@@ -3,17 +3,24 @@
 import bpy
 
 from abc import ABC, abstractmethod
+from setup_wizard.domain.character_types import CharacterType
 
 from setup_wizard.domain.game_types import GameType
+from setup_wizard.utils.genshin_body_part_deducer import get_monster_body_part_name
 
 
 class MaterialDataAppliersFactory:
-    def create(game_type, material_data_parser, body_part):
+    def create(game_type, material_data_parser, body_part, character_type: CharacterType):
         WEAPON_NAME_IDENTIFIER = 'Mat'
 
         if game_type == GameType.GENSHIN_IMPACT.name:
             # Was tempted to add another check, but holding off for now: file.name.startswith('Equip')
             is_weapon = body_part == WEAPON_NAME_IDENTIFIER
+            is_monster = character_type is CharacterType.MONSTER
+
+            if is_monster:
+                # ex. 'XXX_None_Mat.json', try to determine the body part to apply this material data to
+                body_part = get_monster_body_part_name(body_part)
 
             if is_weapon:
                 # V2_WeaponMaterialDataApplier is technically unnecessary for now, does same logic as V2_MaterialDataApplier

--- a/setup_wizard/material_data_import_setup/material_data_applier.py
+++ b/setup_wizard/material_data_import_setup/material_data_applier.py
@@ -200,6 +200,7 @@ class V2_MaterialDataApplier(MaterialDataApplier):
         '_FirstShadowMultColor3': 'Daytime Shadow Color 3',
         '_FirstShadowMultColor4': 'Daytime Shadow Color 4',
         '_FirstShadowMultColor5': 'Daytime Shadow Color 5',
+        "_UseShadowRamp": "Use Shadow Ramp",
     }
 
     shader_node_tree_node_name = 'Group.006'

--- a/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
+++ b/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
@@ -59,7 +59,7 @@ class GenshinImpactDefaultMaterialReplacer(GameDefaultMaterialReplacer):
                     # Dainsleif and Paimon are the only characters with Cloak materials
                     self.blender_operator.report({'INFO'}, 'Dress detected on character model!')
 
-                    actual_material_for_dress = get_actual_material_name_for_dress(material_name, character_type)
+                    actual_material_for_dress = get_actual_material_name_for_dress(material_name, character_type.name)
                     if actual_material_for_dress == 'Cloak':
                         # short-circuit, no shader available for 'Cloak' so do nothing (Paimon)
                         continue

--- a/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
+++ b/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
@@ -6,6 +6,7 @@ from bpy.types import Context, Operator
 
 from setup_wizard.import_order import get_actual_material_name_for_dress
 from setup_wizard.domain.game_types import GameType
+from setup_wizard.texture_import_setup.texture_importer_types import TextureImporterType
 
 
 class GameDefaultMaterialReplacer(ABC):
@@ -36,8 +37,19 @@ class GenshinImpactDefaultMaterialReplacer(GameDefaultMaterialReplacer):
         for mesh in meshes:
             for material_slot in mesh.material_slots:
                 material_name = material_slot.name
-                mesh_body_part_name = self.__get_npc_mesh_body_part_name(material_name) if \
-                    material_name.startswith('NPC') else material_name.split('_')[-1]
+                mesh_body_part_name = None
+                character_type = None
+
+                if material_name.startswith('NPC'):
+                    mesh_body_part_name = self.__get_npc_mesh_body_part_name(material_name)
+                    character_type = TextureImporterType.NPC
+                elif material_name.startswith('Monster'):
+                    mesh_body_part_name = self.__get_monster_mesh_body_part_name(material_name)
+                    character_type = TextureImporterType.MONSTER
+                else:
+                    mesh_body_part_name = material_name.split('_')[-1]
+                    character_type = TextureImporterType.AVATAR
+
                 genshin_material = bpy.data.materials.get(f'miHoYo - Genshin {mesh_body_part_name}')
 
                 if genshin_material:
@@ -47,7 +59,7 @@ class GenshinImpactDefaultMaterialReplacer(GameDefaultMaterialReplacer):
                     # Dainsleif and Paimon are the only characters with Cloak materials
                     self.blender_operator.report({'INFO'}, 'Dress detected on character model!')
 
-                    actual_material_for_dress = get_actual_material_name_for_dress(material_name)
+                    actual_material_for_dress = get_actual_material_name_for_dress(material_name, character_type)
                     if actual_material_for_dress == 'Cloak':
                         # short-circuit, no shader available for 'Cloak' so do nothing (Paimon)
                         continue
@@ -81,6 +93,18 @@ class GenshinImpactDefaultMaterialReplacer(GameDefaultMaterialReplacer):
             return 'Body'
         elif 'Dress' in material_name:  # I don't think this is a valid case, either they use Hair or Body textures
             return 'Dress'
+        else:
+            return None
+
+    def __get_monster_mesh_body_part_name(self, material_name):
+        if 'Hair' in material_name:
+            return 'Hair'
+        elif 'Face' in material_name:
+            return 'Face'
+        elif 'Body' in material_name:
+            return 'Body'
+        elif 'Dress' in material_name:
+            return 'Dress'  # TODO: Not sure if all 'Dress' are 'Body'
         else:
             return None
 

--- a/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
+++ b/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
@@ -106,7 +106,7 @@ class GenshinImpactDefaultMaterialReplacer(GameDefaultMaterialReplacer):
         elif 'Dress' in material_name:
             return 'Dress'  # TODO: Not sure if all 'Dress' are 'Body'
         else:
-            return None
+            return 'Body'  # Assumption that everything else should be a Body material
 
     def __clone_material_and_rename(self, material_slot, mesh_body_part_name_template, mesh_body_part_name):
         new_material = bpy.data.materials.get(mesh_body_part_name_template).copy()

--- a/setup_wizard/texture_import_setup/game_texture_importers.py
+++ b/setup_wizard/texture_import_setup/game_texture_importers.py
@@ -76,7 +76,7 @@ class GenshinImpactTextureImporterFacade(GameTextureImporter):
         texture_importer.import_textures(directory)
 
         '''
-            NPCs don't typically have shadow ramps. Turn off using shadow ramp if there are no assets for it.
+            NPCs and Monsters don't typically have shadow ramps. Turn off using shadow ramp if there are no assets for it.
             If an asset does exist, leave it as the default value (1.0).
         '''
         if (texture_importer_type is TextureImporterType.NPC or texture_importer_type is TextureImporterType.MONSTER) and \
@@ -86,6 +86,7 @@ class GenshinImpactTextureImporterFacade(GameTextureImporter):
                     bpy.data.materials.get('miHoYo - Genshin Hair'),
                     bpy.data.materials.get('miHoYo - Genshin Face'),
                     bpy.data.materials.get('miHoYo - Genshin Body'),
+                    bpy.data.materials.get('miHoYo - Genshin Dress'),
                 ],
                 node_name = 'miHoYo - Genshin Impact',
                 input_name = 'Use Shadow Ramp',

--- a/setup_wizard/texture_import_setup/game_texture_importers.py
+++ b/setup_wizard/texture_import_setup/game_texture_importers.py
@@ -65,9 +65,9 @@ class GenshinImpactTextureImporterFacade(GameTextureImporter):
 
         texture_importer_type = ''
         
-        if [material_name for material_name, material in bpy.data.materials.items() if 'Avatar' in material_name and 'Avatar_Default_Mat'.lower() not in material_name.lower()]:
+        if [material_name for material_name, material in bpy.data.materials.items() if 'Avatar'.lower() in material_name.lower() and 'Avatar_Default_Mat'.lower() not in material_name.lower()]:
             texture_importer_type = TextureImporterType.AVATAR
-        elif [material_name for material_name, material in bpy.data.materials.items() if 'Monster' in material_name]:
+        elif [material_name for material_name, material in bpy.data.materials.items() if 'Monster'.lower() in material_name.lower()]:
             texture_importer_type = TextureImporterType.MONSTER
         else:
             texture_importer_type = TextureImporterType.NPC

--- a/setup_wizard/texture_import_setup/game_texture_importers.py
+++ b/setup_wizard/texture_import_setup/game_texture_importers.py
@@ -65,7 +65,7 @@ class GenshinImpactTextureImporterFacade(GameTextureImporter):
 
         texture_importer_type = ''
         
-        if [material_name for material_name, material in bpy.data.materials.items() if 'Avatar' in material_name]:
+        if [material_name for material_name, material in bpy.data.materials.items() if 'Avatar' in material_name and 'Avatar_Default_Mat'.lower() not in material_name.lower()]:
             texture_importer_type = TextureImporterType.AVATAR
         elif [material_name for material_name, material in bpy.data.materials.items() if 'Monster' in material_name]:
             texture_importer_type = TextureImporterType.MONSTER

--- a/setup_wizard/texture_import_setup/game_texture_importers.py
+++ b/setup_wizard/texture_import_setup/game_texture_importers.py
@@ -63,9 +63,15 @@ class GenshinImpactTextureImporterFacade(GameTextureImporter):
             )
             return {'FINISHED'}
 
-        texture_importer_type = TextureImporterType.AVATAR if \
-            [material_name for material_name, material in bpy.data.materials.items() if 'Avatar' in material_name] else \
-                TextureImporterType.NPC
+        texture_importer_type = ''
+        
+        if [material_name for material_name, material in bpy.data.materials.items() if 'Avatar' in material_name]:
+            texture_importer_type = TextureImporterType.AVATAR
+        elif [material_name for material_name, material in bpy.data.materials.items() if 'Monster' in material_name]:
+            texture_importer_type = TextureImporterType.MONSTER
+        else:
+            texture_importer_type = TextureImporterType.NPC
+
         texture_importer: GenshinTextureImporter = TextureImporterFactory.create(texture_importer_type)
         texture_importer.import_textures(directory)
 
@@ -73,7 +79,7 @@ class GenshinImpactTextureImporterFacade(GameTextureImporter):
             NPCs don't typically have shadow ramps. Turn off using shadow ramp if there are no assets for it.
             If an asset does exist, leave it as the default value (1.0).
         '''
-        if texture_importer_type is TextureImporterType.NPC and \
+        if (texture_importer_type is TextureImporterType.NPC or texture_importer_type is TextureImporterType.MONSTER) and \
             not [file for file in [file for name, folder, file in os.walk(directory)][0] if 'Shadow_Ramp' in file]:
             ShaderConfigurator().update_shader_value(
                 materials = [

--- a/setup_wizard/texture_import_setup/outline_texture_importers.py
+++ b/setup_wizard/texture_import_setup/outline_texture_importers.py
@@ -99,7 +99,7 @@ class GenshinImpactOutlineTextureImporter(OutlineTextureImporter):
                 else:
                     original_mesh_material = [material for material in bpy.data.materials if material.name.endswith(f'Mat_{body_part_material_name}')][0]
                     character_type = TextureImporterType.AVATAR
-                actual_material_part_name = get_actual_material_name_for_dress(original_mesh_material.name, character_type)
+                actual_material_part_name = get_actual_material_name_for_dress(original_mesh_material.name, character_type.name)
 
                 if 'Face' not in actual_material_part_name and 'Face' not in body_part_material_name:
                     if character_type is TextureImporterType.MONSTER:

--- a/setup_wizard/texture_import_setup/outline_texture_importers.py
+++ b/setup_wizard/texture_import_setup/outline_texture_importers.py
@@ -94,12 +94,16 @@ class GenshinImpactOutlineTextureImporter(OutlineTextureImporter):
                     character_type = TextureImporterType.NPC
                 elif [material for material in bpy.data.materials if material.name.startswith('Monster')]:
                     # Assuming all body parts are Body for now
-                    original_mesh_material = [material for material in bpy.data.materials if material.name.startswith('Monster') and 'Body' in material.name][0]
+                    # original_mesh_material = [material for material in bpy.data.materials if material.name.startswith('Monster') and 'Body' in material.name][0]
                     character_type = TextureImporterType.MONSTER
                 else:
                     original_mesh_material = [material for material in bpy.data.materials if material.name.endswith(f'Mat_{body_part_material_name}')][0]
                     character_type = TextureImporterType.AVATAR
-                actual_material_part_name = get_actual_material_name_for_dress(original_mesh_material.name, character_type.name)
+
+                if character_type == TextureImporterType.MONSTER:
+                    actual_material_part_name = 'Body'
+                else:
+                    actual_material_part_name = get_actual_material_name_for_dress(original_mesh_material.name, character_type.name)
 
                 if 'Face' not in actual_material_part_name and 'Face' not in body_part_material_name:
                     if character_type is TextureImporterType.MONSTER:

--- a/setup_wizard/texture_import_setup/outline_texture_importers.py
+++ b/setup_wizard/texture_import_setup/outline_texture_importers.py
@@ -24,7 +24,7 @@ class OutlineTextureImporter(ABC):
         v2_lightmap_node_name = 'Outline_Lightmap'
         outline_material = bpy.data.materials.get(f'miHoYo - Genshin {body_part_material_name} Outlines')
 
-        lightmap_filename = [file for file in lightmap_files if actual_material_part_name in file][0]
+        lightmap_filename = [file for file in lightmap_files if actual_material_part_name in file][0]  # TODO: Unable to determine between character/equipment textures for Monsters
         lightmap_node = outline_material.node_tree.nodes.get(v2_lightmap_node_name) \
             or outline_material.node_tree.nodes.get(v1_lightmap_node_name)
         self.assign_texture_to_node(lightmap_node, character_model_folder_file_path, lightmap_filename)

--- a/setup_wizard/texture_import_setup/outline_texture_importers.py
+++ b/setup_wizard/texture_import_setup/outline_texture_importers.py
@@ -93,8 +93,8 @@ class GenshinImpactOutlineTextureImporter(OutlineTextureImporter):
                     original_mesh_material = [material for material in bpy.data.materials if material.name.startswith('NPC') and body_part_material_name in material.name][0]
                     character_type = TextureImporterType.NPC
                 elif [material for material in bpy.data.materials if material.name.startswith('Monster')]:
-                    if body_part_material_name == 'Body':
-                        original_mesh_material = [material for material in bpy.data.materials if material.name.startswith('Monster') and body_part_material_name in material.name][0]
+                    # Assuming all body parts are Body for now
+                    original_mesh_material = [material for material in bpy.data.materials if material.name.startswith('Monster') and 'Body' in material.name][0]
                     character_type = TextureImporterType.MONSTER
                 else:
                     original_mesh_material = [material for material in bpy.data.materials if material.name.endswith(f'Mat_{body_part_material_name}')][0]

--- a/setup_wizard/texture_import_setup/texture_importer_types.py
+++ b/setup_wizard/texture_import_setup/texture_importer_types.py
@@ -35,8 +35,9 @@ class TextureImporterFactory:
 
 
 class GenshinTextureImporter:
-    def __init__(self, game_type: GameType):
+    def __init__(self, game_type: GameType, character_type: TextureImporterType):
         self.game_type = game_type
+        self.character_type = character_type
 
     def import_textures(self, directory):
         raise NotImplementedError()
@@ -81,7 +82,7 @@ class GenshinTextureImporter:
         material.node_tree.nodes[f'{type.value}_Diffuse_UV1'].image = img
 
         if self.game_type == GameType.GENSHIN_IMPACT:
-            self.setup_dress_textures(f'{type.value}_Diffuse', img)
+            self.setup_dress_textures(f'{type.value}_Diffuse', img, self.character_type)
 
     def set_lightmap_texture(self, type: TextureType, material, img):
         img.colorspace_settings.name='Non-Color'
@@ -89,7 +90,7 @@ class GenshinTextureImporter:
         material.node_tree.nodes[f'{type.value}_Lightmap_UV1'].image = img
         
         if self.game_type == GameType.GENSHIN_IMPACT:
-            self.setup_dress_textures(f'{type.value}_Lightmap', img)
+            self.setup_dress_textures(f'{type.value}_Lightmap', img, self.character_type)
 
     def set_normalmap_texture(self, type: TextureType, material, img):
         img.colorspace_settings.name='Non-Color'
@@ -97,7 +98,7 @@ class GenshinTextureImporter:
         material.node_tree.nodes[f'{type.value}_Normalmap_UV1'].image = img
         
         if self.game_type == GameType.GENSHIN_IMPACT:
-            self.setup_dress_textures(f'{type.value}_Normalmap', img)
+            self.setup_dress_textures(f'{type.value}_Normalmap', img, self.character_type)
 
         # Deprecated. Tries only if it exists. Only for V1 Shader
         self.plug_normal_map(f'miHoYo - Genshin {type.value}', 'MUTE IF ONLY 1 UV MAP EXISTS')
@@ -126,7 +127,7 @@ class GenshinTextureImporter:
     def set_metalmap_texture(self, img):
         bpy.data.node_groups['Metallic Matcap'].nodes['MetalMap'].image = img
 
-    def setup_dress_textures(self, texture_name, texture_img):
+    def setup_dress_textures(self, texture_name, texture_img, character_type: TextureImporterType):
         shader_dress_materials = [material for material in bpy.data.materials if 'Genshin Dress' in material.name]
         shader_cloak_materials = [material for material in bpy.data.materials
                                   if 'Genshin Arm' in material.name or 'Genshin Cloak' in material.name]
@@ -139,7 +140,7 @@ class GenshinTextureImporter:
             original_cloak_material = [material for material in bpy.data.materials if material.name.endswith(
                 shader_cloak_materials[0].name.split(' ')[-1]
             )][0]  # the material that ends with 'Dress', 'Dress1', 'Dress2'
-            actual_cloak_material = get_actual_material_name_for_dress(original_cloak_material.name)
+            actual_cloak_material = get_actual_material_name_for_dress(original_cloak_material.name, character_type.name)
             if actual_cloak_material in texture_name:
                 material_shader_nodes = bpy.data.materials.get(shader_cloak_materials[0].name).node_tree.nodes
                 material_shader_nodes.get(f'{texture_name}_UV0').image = texture_img
@@ -150,7 +151,7 @@ class GenshinTextureImporter:
                 shader_dress_material.name.split(' ')[-1]
             )][0]  # the material that ends with 'Dress', 'Dress1', 'Dress2'
 
-            actual_material = get_actual_material_name_for_dress(original_dress_material.name)
+            actual_material = get_actual_material_name_for_dress(original_dress_material.name, character_type.name)
             if actual_material in texture_name:
                 print(f'Importing texture "{texture_name}" onto material "{shader_dress_material.name}"')
                 material_shader_nodes = bpy.data.materials.get(shader_dress_material.name).node_tree.nodes
@@ -182,7 +183,7 @@ class GenshinTextureImporter:
 
 class GenshinAvatarTextureImporter(GenshinTextureImporter):
     def __init__(self):
-        super().__init__(GameType.GENSHIN_IMPACT)
+        super().__init__(GameType.GENSHIN_IMPACT, TextureImporterType.AVATAR)
 
     def import_textures(self, directory):
         for name, folder, files in os.walk(directory):
@@ -231,7 +232,7 @@ class GenshinAvatarTextureImporter(GenshinTextureImporter):
 
 class GenshinNPCTextureImporter(GenshinTextureImporter):
     def __init__(self):
-        super().__init__(GameType.GENSHIN_IMPACT)
+        super().__init__(GameType.GENSHIN_IMPACT, TextureImporterType.NPC)
 
     def import_textures(self, directory):
         for name, folder, files in os.walk(directory):
@@ -299,7 +300,7 @@ class GenshinNPCTextureImporter(GenshinTextureImporter):
 
 class GenshinMonsterTextureImporter(GenshinTextureImporter):
     def __init__(self):
-        super().__init__(GameType.GENSHIN_IMPACT)
+        super().__init__(GameType.GENSHIN_IMPACT, TextureImporterType.MONSTER)
 
     def import_textures(self, directory):
         for name, folder, files in os.walk(directory):
@@ -368,7 +369,7 @@ class HonkaiStarRailTextureImporter(GenshinTextureImporter):
 
 class HonkaiStarRailAvatarTextureImporter(HonkaiStarRailTextureImporter):
     def __init__(self):
-        super().__init__(GameType.HONKAI_STAR_RAIL)
+        super().__init__(GameType.HONKAI_STAR_RAIL, TextureImporterType.HSR_AVATAR)
 
     def import_textures(self, directory):
         for name, folder, files in os.walk(directory):

--- a/setup_wizard/ui/gi_ui_setup_wizard_menu.py
+++ b/setup_wizard/ui/gi_ui_setup_wizard_menu.py
@@ -183,6 +183,7 @@ class GI_PT_UI_Outlines_Menu(Panel):
     def draw(self, context):
         layout = self.layout
         sub_layout = layout.column()
+        scene = context.scene
 
         if bpy.app.version >= (3,3,0):
             OperatorFactory.create(
@@ -204,6 +205,10 @@ class GI_PT_UI_Outlines_Menu(Panel):
                 'FILE_FOLDER',
                 game_type=GameType.GENSHIN_IMPACT.name,
             )
+
+            sub_layout = layout.box()
+            sub_layout.prop_search(scene, 'setup_wizard_material_for_material_data_import', bpy.data, 'materials')
+            sub_layout.prop_search(scene, 'setup_wizard_outlines_material_for_material_data_import', bpy.data, 'materials')
             OperatorFactory.create(
                 sub_layout,
                 'genshin.import_material_data',

--- a/setup_wizard/utils/genshin_body_part_deducer.py
+++ b/setup_wizard/utils/genshin_body_part_deducer.py
@@ -14,3 +14,16 @@ def get_monster_body_part_name(name):
             return 'Body'  # TODO: Current assumption/belief all None are Body-type
         else:
             return None
+
+
+def get_npc_mesh_body_part_name(material_name):
+    if 'Hair' in material_name:
+        return 'Hair'
+    elif 'Face' in material_name:
+        return 'Face'
+    elif 'Body' in material_name:
+        return 'Body'
+    elif 'Dress' in material_name:  # I don't think this is a valid case, either they use Hair or Body textures
+        return 'Dress'
+    else:
+        return None

--- a/setup_wizard/utils/genshin_body_part_deducer.py
+++ b/setup_wizard/utils/genshin_body_part_deducer.py
@@ -13,7 +13,8 @@ def get_monster_body_part_name(name):
         elif 'None' in name:
             return 'Body'  # TODO: Current assumption/belief all None are Body-type
         else:
-            return None
+            print(f'"Best Guess" attempt made for retrieving mosnter body part name {name}')
+            return 'Body'
 
 
 def get_npc_mesh_body_part_name(material_name):

--- a/setup_wizard/utils/genshin_body_part_deducer.py
+++ b/setup_wizard/utils/genshin_body_part_deducer.py
@@ -10,5 +10,7 @@ def get_monster_body_part_name(name):
             return 'Body'
         elif 'Dress' in name:
             return 'Dress'  # TODO: Not sure if all 'Dress' are 'Body'
+        elif 'None' in name:
+            return 'Body'  # TODO: Current assumption/belief all None are Body-type
         else:
-            return 'Body'  # Assumption that everything else should be a Body material
+            return None

--- a/setup_wizard/utils/genshin_body_part_deducer.py
+++ b/setup_wizard/utils/genshin_body_part_deducer.py
@@ -1,0 +1,14 @@
+# Author: michael-gh1
+
+
+def get_monster_body_part_name(name):
+        if 'Hair' in name:
+            return 'Hair'
+        elif 'Face' in name:
+            return 'Face'
+        elif 'Body' in name:
+            return 'Body'
+        elif 'Dress' in name:
+            return 'Dress'  # TODO: Not sure if all 'Dress' are 'Body'
+        else:
+            return 'Body'  # Assumption that everything else should be a Body material


### PR DESCRIPTION
Some old commits from a few months ago.

* Adds support for some NPC and Monster setup (like Eremites, Fatui, etc.)
* New feature to target materials (the Target Material and Outlines Material) for importing material data