### PR TITLE
chore: update node group name for latest version of outlines file

### DIFF
--- a/setup_wizard/outline_import_setup/outline_node_groups.py
+++ b/setup_wizard/outline_import_setup/outline_node_groups.py
@@ -2,5 +2,5 @@
 
 
 class OutlineNodeGroupNames:
-    FESTIVITY_GENSHIN_OUTLINES = 'miHoYo - Outlines'
+    FESTIVITY_GENSHIN_OUTLINES = 'Genshin - Outlines GN'
     NYA222_HSR_OUTLINES = 'HoYoverse - Outlines'


### PR DESCRIPTION
Fixes broken geometry nodes setup due to Setup Wizard expecting and looking for a different node group name.

- https://github.com/festivities/Blender-miHoYo-Shaders/blob/main/Genshin%20-%20Outlines.blend