### PR TITLE
fix: Furina - Use Hair Output for Face material / GI V3 Shader Support

### DIFF
--- a/setup_wizard/domain/shader_node_names.py
+++ b/setup_wizard/domain/shader_node_names.py
@@ -8,6 +8,7 @@ class ShaderNodeNames:
     FACE_MATERIAL_ID = ''
     USE_SHADOW_RAMP = ''
     USE_LIGHTMAP_AO = ''
+    DEPTH_BASED_RIM = ''
 
 
 class V2_GenshinShaderNodeNames(ShaderNodeNames):
@@ -17,6 +18,7 @@ class V2_GenshinShaderNodeNames(ShaderNodeNames):
     FACE_MATERIAL_ID = 'Face Material ID'
     USE_SHADOW_RAMP = 'Use Shadow Ramp'
     USE_LIGHTMAP_AO = 'Use Lightmap AO'
+    DEPTH_BASED_RIM = 'Group.010'
 
 
 class V3_GenshinShaderNodeNames(ShaderNodeNames):

--- a/setup_wizard/material_data_import_setup/material_data_applier.py
+++ b/setup_wizard/material_data_import_setup/material_data_applier.py
@@ -307,9 +307,13 @@ class V3_MaterialDataApplier(V2_MaterialDataApplier):
         '_FaceBlushColor': 'Face Blush Color',
         '_FaceBlushStrength': 'Face Blush Strength',
         '_FaceMapSoftness': 'Face Shadow Softness',  # material data values are either 0.001 or 1E-06
-        '_UseShadowRamp': 'Use Shadow Ramp',
-        '_CoolShadowMultColor': 'Nighttime Shadow Color',
-        '_FirstShadowMultColor': 'Daytime Shadow Color',
+        '_CoolShadowMultColor': 'Nighttime Shadow Color',  # Teeth
+        '_CoolShadowMultColor': 'Nighttime Shadow Color',  # Teeth
+        '_CoolShadowMultColor2': 'Nighttime Shadow Color 2',  # Teeth
+        '_CoolShadowMultColor3': 'Nighttime Shadow Color 3',  # Teeth
+        '_FirstShadowMultColor': 'Daytime Shadow Color',  # Teeth
+        '_FirstShadowMultColor2': 'Daytime Shadow Color 2',  # Teeth
+        '_FirstShadowMultColor3': 'Daytime Shadow Color 3',  # Teeth
     }
 
     outline_mapping = {

--- a/setup_wizard/texture_import_setup/texture_importer_types.py
+++ b/setup_wizard/texture_import_setup/texture_importer_types.py
@@ -245,9 +245,9 @@ class GenshinTextureImporter:
 
         shader_node_names = V2_GenshinShaderNodeNames if \
             self.genshin_shader_version is GenshinImpactShaders.V2_GENSHIN_IMPACT_SHADER else V3_GenshinShaderNodeNames
-        shader_has_face_material_id = self.genshin_shader_version is GenshinImpactShaders.V3_GENSHIN_IMPACT_SHADER or \
-            self.genshin_shader_version is GenshinImpactShaders.V2_GENSHIN_IMPACT_SHADER
+        shader_has_face_material_id = self.genshin_shader_version is GenshinImpactShaders.V2_GENSHIN_IMPACT_SHADER
 
+        # No longer a field in V3 shader
         if shader_has_face_material_id:
             for character_name in character_to_face_material_id_map.keys():
                 if character_name in image.name:
@@ -256,25 +256,17 @@ class GenshinTextureImporter:
                         face_shader_node.inputs[shader_node_names.FACE_MATERIAL_ID].default_value = \
                             character_to_face_material_id_map[character_name]
 
-    def set_body_hair_ramps_on_face_shader(self, face_material, image):
-        character_to_body_hair_ramps_map = {
-            'Funingna': 1,  # Furina
-        }
+    def set_body_hair_output_on_face_shader(self, face_material, image):
+        characters_needing_hair_output = [
+            'Funingna',  # Furina
+        ]
 
         shader_node_names = V2_GenshinShaderNodeNames if \
             self.genshin_shader_version is GenshinImpactShaders.V2_GENSHIN_IMPACT_SHADER else V3_GenshinShaderNodeNames
-        shader_has_body_hair_ramps = self.genshin_shader_version is GenshinImpactShaders.V3_GENSHIN_IMPACT_SHADER
         shader_has_body_hair_output = self.genshin_shader_version is GenshinImpactShaders.V2_GENSHIN_IMPACT_SHADER
 
-        if shader_has_body_hair_ramps:
-            for character_name in character_to_body_hair_ramps_map.keys():
-                if character_name in image.name:
-                    if face_material.node_tree.nodes.get(shader_node_names.FACE_SHADER):
-                        face_shader_node = face_material.node_tree.nodes[shader_node_names.FACE_SHADER]
-                        face_shader_node.inputs[shader_node_names.BODY_HAIR_RAMPS].default_value = \
-                            character_to_body_hair_ramps_map[character_name]
-        elif shader_has_body_hair_output:
-            for character_name in character_to_body_hair_ramps_map.keys():
+        if shader_has_body_hair_output:
+            for character_name in characters_needing_hair_output:
                 if character_name in image.name and face_material.node_tree.nodes.get(shader_node_names.FACE_SHADER):
                     face_shader_node = face_material.node_tree.nodes[shader_node_names.FACE_SHADER]
                     face_shader_node_hair_output = face_shader_node.outputs.get('Hair')
@@ -369,7 +361,7 @@ class GenshinAvatarTextureImporter(GenshinTextureImporter):
                     # Set Face Id in Body_Diffuse because not all Face Diffuse filenames have the full costume name
                     # Ex. Diluc's costume does not have DilucCostumeFlamme, but just Diluc
                     self.set_face_material_id(face_material, img)
-                    self.set_body_hair_ramps_on_face_shader(face_material, img)
+                    self.set_body_hair_output_on_face_shader(face_material, img)
                 elif "Body_Lightmap" in file:
                     self.set_lightmap_texture(TextureType.BODY, body_material, img)
                 elif "Body_Normalmap" in file:


### PR DESCRIPTION
* Use `Hair` output for `Face` material on Furina (instead of `Body` output)