### PR TITLE
feat: save shader/outlines filepath preferences to Blender's config folder

### DIFF
--- a/setup_wizard/genshin_gran_turismo_tonemapper_setup.py
+++ b/setup_wizard/genshin_gran_turismo_tonemapper_setup.py
@@ -6,7 +6,7 @@ import os
 from bpy_extras.io_utils import ImportHelper
 from bpy.props import StringProperty
 from bpy.types import Operator
-from setup_wizard.import_order import cache_using_cache_key, get_cache, FESTIVITY_GRAN_TURISMO_FILE_PATH
+from setup_wizard.import_order import cache_using_cache_key, get_cache, GENSHIN_IMPACT_GRAN_TURISMO_FILE_PATH
 
 from setup_wizard.setup_wizard_operator_base_classes import CustomOperatorProperties
 
@@ -50,7 +50,7 @@ class GI_OT_GenshinGranTurismoTonemapperSetup(Operator, ImportHelper, CustomOper
 
     def execute(self, context):
         cache_enabled = context.window_manager.cache_enabled
-        gran_turismo_blend_file_path = self.filepath or get_cache(cache_enabled).get(FESTIVITY_GRAN_TURISMO_FILE_PATH)
+        gran_turismo_blend_file_path = self.filepath or get_cache(cache_enabled).get(GENSHIN_IMPACT_GRAN_TURISMO_FILE_PATH)
 
         if not bpy.data.scenes.get(NAME_OF_DEFAULT_SCENE).node_tree:
             self.logs += 'ERROR: Must enable "Use Nodes" in Compositor view before being able to set up GT Tonemapper\n'
@@ -96,7 +96,7 @@ class GI_OT_GenshinGranTurismoTonemapperSetup(Operator, ImportHelper, CustomOper
         if cache_enabled and gran_turismo_blend_file_path:
             cache_using_cache_key(
                 get_cache(cache_enabled), 
-                FESTIVITY_GRAN_TURISMO_FILE_PATH, 
+                GENSHIN_IMPACT_GRAN_TURISMO_FILE_PATH, 
                 gran_turismo_blend_file_path
             )
 

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -13,6 +13,8 @@ COMPONENT_NAME = 'component_name'
 ENABLED = 'enabled'
 CACHE_KEY = 'cache_key'
 UI_ORDER_CONFIG_KEY = 'ui_order'
+BLENDER_ADDON_CONFIG_FILENAME = f'character_{__package__}.json'
+BLENDER_ADDON_CONFIG_FILEPATH = os.path.join(bpy.utils.user_resource('CONFIG'), BLENDER_ADDON_CONFIG_FILENAME)
 
 # Cache Constants
 FESTIVITY_ROOT_FOLDER_FILE_PATH = 'festivity_root_folder_file_path'
@@ -109,50 +111,47 @@ def invoke_next_step_ui(
         game_type=game_type,
     )
 
+def read_from_blender_cache():
+    try:
+        with open(BLENDER_ADDON_CONFIG_FILEPATH, 'r') as json_file:
+            print(f'Reading from user Blender config: {BLENDER_ADDON_CONFIG_FILEPATH}')
+            config = json.load(json_file)
+            print(f'Retrieved user Blender config')
+            return config
+    except FileNotFoundError as err:
+        return {}
+
 
 def get_cache(cache_enabled=True):
     if not cache_enabled:
         return {}
-    path_to_setup_wizard_folder = os.path.dirname(os.path.abspath(__file__))
+    return read_from_blender_cache()
 
-    cache_file_path = f'{path_to_setup_wizard_folder}/cache.json.tmp'
-    if not os.path.exists(cache_file_path):
-        return {}
-    cache_file = open(cache_file_path)
-    cache = json.load(cache_file)
-    return cache
-
+def write_to_blender_cache(config):
+    with open(BLENDER_ADDON_CONFIG_FILEPATH, 'w') as json_file:
+        print(f'Writing to user Blender config: {BLENDER_ADDON_CONFIG_FILEPATH}')
+        json_string = json.dumps(config, indent=4)
+        json_file.write(json_string)
+        print(f'Successfully wrote to user Blender config')
 
 def cache_previous_step_file_path(cache, last_step, file_path_to_cache):
     if not file_path_to_cache:
         return
-    path_to_setup_wizard_folder = os.path.dirname(os.path.abspath(__file__))
-    cache_file_path = f'{path_to_setup_wizard_folder}/cache.json.tmp'
     step_cache_key = last_step.get(CACHE_KEY)
 
     print(f'Assigning `{step_cache_key}:{file_path_to_cache}` in cache')
     cache[step_cache_key] = file_path_to_cache
-    with open(cache_file_path, 'w', encoding='utf-8') as f:
-        json.dump(cache, f, ensure_ascii=False, indent=4)
-
+    write_to_blender_cache(cache)
 
 def cache_using_cache_key(cache, cache_key, file_path_for_cache):
     if not file_path_for_cache:
         return
-    path_to_setup_wizard_folder = os.path.dirname(os.path.abspath(__file__))
-    cache_file_path = f'{path_to_setup_wizard_folder}/cache.json.tmp'
-
     print(f'Assigning `{cache_key}:{file_path_for_cache}` in cache')
     cache[cache_key] = file_path_for_cache
-    with open(cache_file_path, 'w', encoding='utf-8') as f:
-        json.dump(cache, f, ensure_ascii=False, indent=4)
-
+    write_to_blender_cache(cache)
 
 def clear_cache():
-    path_to_setup_wizard_folder = os.path.dirname(os.path.abspath(__file__))
-    cache_file_path = f'{path_to_setup_wizard_folder}/cache.json.tmp'
-    with open(cache_file_path, 'w') as f:
-        json.dump({}, f)
+    write_to_blender_cache({})
 
 
 def clear_cache(game_type: str):
@@ -183,12 +182,7 @@ def clear_cache(game_type: str):
             cache[NYA222_HONKAI_STAR_RAIL_OUTLINES_FILE_PATH] = cached_hsr_outlines_file_path
     else:
         cache = {}
-
-    path_to_setup_wizard_folder = os.path.dirname(os.path.abspath(__file__))
-    cache_file_path = f'{path_to_setup_wizard_folder}/cache.json.tmp'
-    with open(cache_file_path, 'w') as f:
-        json_string = json.dumps(cache, indent=4)
-        f.write(json_string)
+    write_to_blender_cache(cache)
 
 
 '''

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -17,19 +17,22 @@ BLENDER_ADDON_CONFIG_FILENAME = f'character_{__package__}.json'
 BLENDER_ADDON_CONFIG_FILEPATH = os.path.join(bpy.utils.user_resource('CONFIG'), BLENDER_ADDON_CONFIG_FILENAME)
 
 # Cache Constants
-FESTIVITY_ROOT_FOLDER_FILE_PATH = 'festivity_root_folder_file_path'
-FESTIVITY_SHADER_FILE_PATH = "festivity_shader_file_path"
-FESTIVITY_OUTLINES_FILE_PATH = 'festivity_outlines_file_path'
-FESTIVITY_GRAN_TURISMO_FILE_PATH = 'festivity_gran_turismo_file_path'
-GENSHIN_RIGIFY_BONE_SHAPES_FILE_PATH = 'genshin_rigify_bone_shapes_file_path'
 CHARACTER_MODEL_FOLDER_FILE_PATH = 'character_model_folder_file_path'
-NYA222_HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH = 'nya222_honkai_star_rail_folder_file_path'
-NYA222_HONKAI_STAR_RAIL_SHADER_FILE_PATH = 'nya222_honkai_star_rail_shader_file_path'
-NYA222_HONKAI_STAR_RAIL_OUTLINES_FILE_PATH = 'nya222_honkai_star_rail_outlines_file_path'
-JAREDNYTS_PGR_ROOT_FOLDER_FILE_PATH = 'jarednyts_pgr_folder_file_path'
-JAREDNYTS_PGR_SHADER_FILE_PATH = 'jarednyts_pgr_shader_file_path'
-JAREDNYTS_PGR_OUTLINES_FILE_PATH = 'jarednyts_pgr_outlines_file_path'
-JAREDNYTS_PGR_CHIBI_MESH_FILE_PATH = 'jarednyts_pgr_chibi_mesh_file_path'
+
+GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH = 'genshin_impact_root_folder_file_path'
+GENSHIN_IMPACT_SHADER_FILE_PATH = "genshin_impact_shader_file_path"
+GENSHIN_IMPACT_OUTLINES_FILE_PATH = 'genshin_impact_outlines_file_path'
+GENSHIN_IMPACT_GRAN_TURISMO_FILE_PATH = 'genshin_impact_gran_turismo_file_path'
+GENSHIN_RIGIFY_BONE_SHAPES_FILE_PATH = 'genshin_rigify_bone_shapes_file_path'
+
+HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH = 'honkai_star_rail_folder_file_path'
+HONKAI_STAR_RAIL_SHADER_FILE_PATH = 'honkai_star_rail_shader_file_path'
+HONKAI_STAR_RAIL_OUTLINES_FILE_PATH = 'honkai_star_rail_outlines_file_path'
+
+PUNISHING_GRAY_RAVEN_ROOT_FOLDER_FILE_PATH = 'punishing_gray_raven_folder_file_path'
+PUNISHING_GRAY_RAVEN_SHADER_FILE_PATH = 'punishing_gray_raven_shader_file_path'
+PUNISHING_GRAY_RAVEN_OUTLINES_FILE_PATH = 'punishing_gray_raven_outlines_file_path'
+PUNISHING_GRAY_RAVEN_CHIBI_MESH_FILE_PATH = 'punishing_gray_raven_chibi_mesh_file_path'
 
 
 class NextStepInvoker:
@@ -157,29 +160,29 @@ def clear_cache():
 def clear_cache(game_type: str):
     cache = get_cache()
     if game_type == GameType.HONKAI_STAR_RAIL.name:
-        cached_gi_root_folder_file_path = cache.get(FESTIVITY_ROOT_FOLDER_FILE_PATH)
-        cached_gi_shader_file_path = cache.get(FESTIVITY_SHADER_FILE_PATH)
-        cached_gi_outlines_file_path = cache.get(FESTIVITY_OUTLINES_FILE_PATH)
+        cached_gi_root_folder_file_path = cache.get(GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH)
+        cached_gi_shader_file_path = cache.get(GENSHIN_IMPACT_SHADER_FILE_PATH)
+        cached_gi_outlines_file_path = cache.get(GENSHIN_IMPACT_OUTLINES_FILE_PATH)
         cache = {}
 
         if cached_gi_root_folder_file_path:
-            cache[FESTIVITY_ROOT_FOLDER_FILE_PATH] = cached_gi_root_folder_file_path
+            cache[GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH] = cached_gi_root_folder_file_path
         if cached_gi_shader_file_path:
-            cache[FESTIVITY_SHADER_FILE_PATH] = cached_gi_shader_file_path
+            cache[GENSHIN_IMPACT_SHADER_FILE_PATH] = cached_gi_shader_file_path
         if cached_gi_shader_file_path:
-            cache[FESTIVITY_OUTLINES_FILE_PATH] = cached_gi_outlines_file_path
+            cache[GENSHIN_IMPACT_OUTLINES_FILE_PATH] = cached_gi_outlines_file_path
     elif game_type == GameType.GENSHIN_IMPACT.name:
-        cached_hsr_root_folder_file_path = cache.get(NYA222_HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH)
-        cached_hsr_shader_file_path = cache.get(NYA222_HONKAI_STAR_RAIL_SHADER_FILE_PATH)
-        cached_hsr_outlines_file_path = cache.get(NYA222_HONKAI_STAR_RAIL_OUTLINES_FILE_PATH)
+        cached_hsr_root_folder_file_path = cache.get(HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH)
+        cached_hsr_shader_file_path = cache.get(HONKAI_STAR_RAIL_SHADER_FILE_PATH)
+        cached_hsr_outlines_file_path = cache.get(HONKAI_STAR_RAIL_OUTLINES_FILE_PATH)
         cache = {}
 
         if cached_hsr_root_folder_file_path:
-            cache[NYA222_HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH] = cached_hsr_root_folder_file_path
+            cache[HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH] = cached_hsr_root_folder_file_path
         if cached_hsr_shader_file_path:
-            cache[NYA222_HONKAI_STAR_RAIL_SHADER_FILE_PATH] = cached_hsr_shader_file_path
+            cache[HONKAI_STAR_RAIL_SHADER_FILE_PATH] = cached_hsr_shader_file_path
         if cached_hsr_outlines_file_path:
-            cache[NYA222_HONKAI_STAR_RAIL_OUTLINES_FILE_PATH] = cached_hsr_outlines_file_path
+            cache[HONKAI_STAR_RAIL_OUTLINES_FILE_PATH] = cached_hsr_outlines_file_path
     else:
         cache = {}
     write_to_blender_cache(cache)

--- a/setup_wizard/import_order.py
+++ b/setup_wizard/import_order.py
@@ -159,32 +159,37 @@ def clear_cache():
 
 def clear_cache(game_type: str):
     cache = get_cache()
-    if game_type == GameType.HONKAI_STAR_RAIL.name:
-        cached_gi_root_folder_file_path = cache.get(GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH)
-        cached_gi_shader_file_path = cache.get(GENSHIN_IMPACT_SHADER_FILE_PATH)
-        cached_gi_outlines_file_path = cache.get(GENSHIN_IMPACT_OUTLINES_FILE_PATH)
-        cache = {}
+    if game_type == GameType.GENSHIN_IMPACT.name:
+        keys_to_delete = [
+            CHARACTER_MODEL_FOLDER_FILE_PATH,
+            GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH,
+            GENSHIN_IMPACT_SHADER_FILE_PATH,
+            GENSHIN_IMPACT_OUTLINES_FILE_PATH,
+            GENSHIN_IMPACT_GRAN_TURISMO_FILE_PATH,
+            GENSHIN_RIGIFY_BONE_SHAPES_FILE_PATH,
+        ]
+        for key in keys_to_delete:
+            cache.pop(key, None)
+    elif game_type == GameType.HONKAI_STAR_RAIL.name:
+        keys_to_delete = [
+            CHARACTER_MODEL_FOLDER_FILE_PATH,
+            HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH,
+            HONKAI_STAR_RAIL_SHADER_FILE_PATH,
+            HONKAI_STAR_RAIL_OUTLINES_FILE_PATH,
+        ]
+        for key in keys_to_delete:
+            cache.pop(key, None)
 
-        if cached_gi_root_folder_file_path:
-            cache[GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH] = cached_gi_root_folder_file_path
-        if cached_gi_shader_file_path:
-            cache[GENSHIN_IMPACT_SHADER_FILE_PATH] = cached_gi_shader_file_path
-        if cached_gi_shader_file_path:
-            cache[GENSHIN_IMPACT_OUTLINES_FILE_PATH] = cached_gi_outlines_file_path
-    elif game_type == GameType.GENSHIN_IMPACT.name:
-        cached_hsr_root_folder_file_path = cache.get(HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH)
-        cached_hsr_shader_file_path = cache.get(HONKAI_STAR_RAIL_SHADER_FILE_PATH)
-        cached_hsr_outlines_file_path = cache.get(HONKAI_STAR_RAIL_OUTLINES_FILE_PATH)
-        cache = {}
-
-        if cached_hsr_root_folder_file_path:
-            cache[HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH] = cached_hsr_root_folder_file_path
-        if cached_hsr_shader_file_path:
-            cache[HONKAI_STAR_RAIL_SHADER_FILE_PATH] = cached_hsr_shader_file_path
-        if cached_hsr_outlines_file_path:
-            cache[HONKAI_STAR_RAIL_OUTLINES_FILE_PATH] = cached_hsr_outlines_file_path
-    else:
-        cache = {}
+    elif game_type == GameType.PUNISHING_GRAY_RAVEN.name:
+        keys_to_delete = [
+            CHARACTER_MODEL_FOLDER_FILE_PATH,
+            PUNISHING_GRAY_RAVEN_ROOT_FOLDER_FILE_PATH,
+            PUNISHING_GRAY_RAVEN_SHADER_FILE_PATH,
+            PUNISHING_GRAY_RAVEN_OUTLINES_FILE_PATH,
+            PUNISHING_GRAY_RAVEN_CHIBI_MESH_FILE_PATH,
+        ]
+        for key in keys_to_delete:
+            cache.pop(key, None)
     write_to_blender_cache(cache)
 
 

--- a/setup_wizard/material_import_setup/game_material_importers.py
+++ b/setup_wizard/material_import_setup/game_material_importers.py
@@ -9,8 +9,8 @@ from setup_wizard.domain.shader_material_names import StellarToonShaderMaterialN
     V2_FestivityGenshinImpactMaterialNames, Nya222HonkaiStarRailShaderMaterialNames, \
     JaredNytsPunishingGrayRavenShaderMaterialNames
 from setup_wizard.import_order import NextStepInvoker, cache_using_cache_key, get_cache, \
-    FESTIVITY_ROOT_FOLDER_FILE_PATH, FESTIVITY_SHADER_FILE_PATH, NYA222_HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH, \
-    NYA222_HONKAI_STAR_RAIL_SHADER_FILE_PATH, JAREDNYTS_PGR_ROOT_FOLDER_FILE_PATH, JAREDNYTS_PGR_SHADER_FILE_PATH
+    GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH, GENSHIN_IMPACT_SHADER_FILE_PATH, HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH, \
+    HONKAI_STAR_RAIL_SHADER_FILE_PATH, PUNISHING_GRAY_RAVEN_ROOT_FOLDER_FILE_PATH, PUNISHING_GRAY_RAVEN_SHADER_FILE_PATH
 from setup_wizard.material_import_setup.empty_names import LightDirectionEmptyNames
 from setup_wizard.outline_import_setup.outline_node_groups import OutlineNodeGroupNames
 
@@ -161,8 +161,8 @@ class GenshinImpactMaterialImporterFacade(GameMaterialImporter):
         super().__init__(
             blender_operator,
             context,
-            FESTIVITY_SHADER_FILE_PATH,
-            FESTIVITY_ROOT_FOLDER_FILE_PATH,
+            GENSHIN_IMPACT_SHADER_FILE_PATH,
+            GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH,
             self.DEFAULT_BLEND_FILE_WITH_GENSHIN_MATERIALS,
             self.NAMES_OF_GENSHIN_MATERIALS
         )
@@ -213,8 +213,8 @@ class HonkaiStarRailMaterialImporterFacade(GameMaterialImporter):
         super().__init__(
             blender_operator,
             context,
-            NYA222_HONKAI_STAR_RAIL_SHADER_FILE_PATH,
-            NYA222_HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH,
+            HONKAI_STAR_RAIL_SHADER_FILE_PATH,
+            HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH,
             self.DEFAULT_BLEND_FILE_WITH_HSR_MATERIALS,
             self.NAMES_OF_HONKAI_STAR_RAIL_MATERIALS
         )
@@ -265,8 +265,8 @@ class PunishingGrayRavenMaterialImporterFacade(GameMaterialImporter):
         super().__init__(
             blender_operator,
             context,
-            JAREDNYTS_PGR_SHADER_FILE_PATH,
-            JAREDNYTS_PGR_ROOT_FOLDER_FILE_PATH,
+            PUNISHING_GRAY_RAVEN_SHADER_FILE_PATH,
+            PUNISHING_GRAY_RAVEN_ROOT_FOLDER_FILE_PATH,
             self.DEFAULT_BLEND_FILE_WITH_PGR_MATERIALS,
             self.NAMES_OF_PUNISHING_GRAY_RAVEN_MATERIALS
         )

--- a/setup_wizard/mesh_import_setup/chibi_face_setup.py
+++ b/setup_wizard/mesh_import_setup/chibi_face_setup.py
@@ -11,7 +11,7 @@ from setup_wizard.domain.game_types import GameType
 from setup_wizard.domain.shader_material_names import JaredNytsPunishingGrayRavenShaderMaterialNames
 from setup_wizard.geometry_nodes_setup.geometry_nodes_setups import PunishingGrayRavenGeometryNodesSetup
 
-from setup_wizard.import_order import CHARACTER_MODEL_FOLDER_FILE_PATH, JAREDNYTS_PGR_CHIBI_MESH_FILE_PATH, NextStepInvoker
+from setup_wizard.import_order import CHARACTER_MODEL_FOLDER_FILE_PATH, PUNISHING_GRAY_RAVEN_CHIBI_MESH_FILE_PATH, NextStepInvoker
 from setup_wizard.import_order import NextStepInvoker, cache_using_cache_key, get_cache
 from setup_wizard.texture_import_setup.texture_node_names import JaredNytsPunishingGrayRavenTextureNodeNames
 
@@ -59,7 +59,7 @@ class PGR_OT_SetUpChibiFace(Operator, ImportHelper, CustomOperatorProperties):
     def __import_chibi_face_mesh(self, cache_enabled):
         user_selected_shader_blend_file_path = self.filepath if \
             self.filepath and not os.path.isdir(self.filepath) else \
-            get_cache(cache_enabled).get(JAREDNYTS_PGR_CHIBI_MESH_FILE_PATH)
+            get_cache(cache_enabled).get(PUNISHING_GRAY_RAVEN_CHIBI_MESH_FILE_PATH)
 
         if not [material for material in bpy.data.materials if self.material_names.CHIBIFACE in material.name]:
             if not user_selected_shader_blend_file_path:
@@ -95,7 +95,7 @@ class PGR_OT_SetUpChibiFace(Operator, ImportHelper, CustomOperatorProperties):
 
             if cache_enabled and (user_selected_shader_blend_file_path):
                 if user_selected_shader_blend_file_path:
-                    cache_using_cache_key(get_cache(cache_enabled), JAREDNYTS_PGR_CHIBI_MESH_FILE_PATH, user_selected_shader_blend_file_path)
+                    cache_using_cache_key(get_cache(cache_enabled), PUNISHING_GRAY_RAVEN_CHIBI_MESH_FILE_PATH, user_selected_shader_blend_file_path)
 
     def __parent_mesh_to_armature(self, chibi_face_mesh, character_armature):
         bpy.context.view_layer.objects.active = character_armature

--- a/setup_wizard/outline_import_setup/outline_importers.py
+++ b/setup_wizard/outline_import_setup/outline_importers.py
@@ -8,7 +8,7 @@ from bpy.types import Operator, Context
 
 from setup_wizard.domain.shader_identifier_service import GenshinImpactShaders, HonkaiStarRailShaders, ShaderIdentifierService, ShaderIdentifierServiceFactory
 from setup_wizard.outline_import_setup.outline_node_groups import OutlineNodeGroupNames
-from setup_wizard.import_order import FESTIVITY_OUTLINES_FILE_PATH, JAREDNYTS_PGR_OUTLINES_FILE_PATH, NYA222_HONKAI_STAR_RAIL_OUTLINES_FILE_PATH, \
+from setup_wizard.import_order import GENSHIN_IMPACT_OUTLINES_FILE_PATH, PUNISHING_GRAY_RAVEN_OUTLINES_FILE_PATH, HONKAI_STAR_RAIL_OUTLINES_FILE_PATH, \
     NextStepInvoker, cache_using_cache_key, get_cache
 from setup_wizard.domain.game_types import GameType
 
@@ -46,7 +46,7 @@ class GenshinImpactOutlineNodeGroupImporter(GameOutlineNodeGroupImporter):
     def __init__(self, blender_operator, context, outlines_node_group_name):
         self.blender_operator = blender_operator
         self.context = context
-        self.outlines_file_path = FESTIVITY_OUTLINES_FILE_PATH  # Keep same filepath for all Genshin Impact
+        self.outlines_file_path = GENSHIN_IMPACT_OUTLINES_FILE_PATH  # Keep same filepath for all Genshin Impact
         self.outlines_node_group_names = outlines_node_group_name
 
     def import_outline_node_group(self):
@@ -86,7 +86,7 @@ class HonkaiStarRailOutlineNodeGroupImporter(GameOutlineNodeGroupImporter):
     def __init__(self, blender_operator, context, outlines_node_group_names):
         self.blender_operator = blender_operator
         self.context = context
-        self.outlines_file_path = NYA222_HONKAI_STAR_RAIL_OUTLINES_FILE_PATH  # Keep same filepath for all HSR
+        self.outlines_file_path = HONKAI_STAR_RAIL_OUTLINES_FILE_PATH  # Keep same filepath for all HSR
         self.outlines_node_group_names = outlines_node_group_names
 
     def import_outline_node_group(self):
@@ -128,7 +128,7 @@ class PunishingGrayRavenOutlineNodeGroupImporter(GameOutlineNodeGroupImporter):
     def __init__(self, blender_operator, context):
         self.blender_operator = blender_operator
         self.context = context
-        self.outlines_file_path = JAREDNYTS_PGR_OUTLINES_FILE_PATH
+        self.outlines_file_path = PUNISHING_GRAY_RAVEN_OUTLINES_FILE_PATH
         self.outlines_node_group_names = \
             OutlineNodeGroupNames.V2_JAREDNYTS_PGR_OUTLINES + OutlineNodeGroupNames.V3_JAREDNYTS_PGR_OUTLINES
 

--- a/setup_wizard/tests/constants.py
+++ b/setup_wizard/tests/constants.py
@@ -1,10 +1,6 @@
 # Key names for the tests' config.json
 BLENDER_EXECUTION_FILE_PATH = 'blender_execution_file_path'
 CHARACTERS_FOLDER_FILE_PATH = 'characters_folder_file_path'
-FESTIVITY_ROOT_FOLDER_FILE_PATH = 'festivity_root_folder_file_path'
-FESTIVITY_SHADER_FILE_PATH = 'festivity_shader_file_path'
-FESTIVITY_OUTLINES_FILE_PATH = 'festivity_outlines_file_path'
-GENSHIN_RIGIFY_BONE_SHAPES_FILE_PATH = 'genshin_rigify_bone_shapes_file_path'
 MATERIAL_JSON_FOLDER_FILE_PATH = 'material_json_folder_file_path'
 RIG_CHARACTER = 'rig_character'
 USER_INPUTTED_MATERIAL_JSONS = 'user_inputted_material_jsons'

--- a/setup_wizard/tests/test_genshin_impact_character_setup.py
+++ b/setup_wizard/tests/test_genshin_impact_character_setup.py
@@ -4,8 +4,9 @@ import logging
 import os
 import sys
 from pathlib import PurePath
-from setup_wizard.tests.constants import FESTIVITY_ROOT_FOLDER_FILE_PATH, \
-    FESTIVITY_SHADER_FILE_PATH, FESTIVITY_OUTLINES_FILE_PATH, GENSHIN_RIGIFY_BONE_SHAPES_FILE_PATH, RIG_CHARACTER
+from setup_wizard.tests.constants import RIG_CHARACTER
+from setup_wizard.import_order import GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH, GENSHIN_IMPACT_SHADER_FILE_PATH, \
+    GENSHIN_IMPACT_OUTLINES_FILE_PATH, GENSHIN_RIGIFY_BONE_SHAPES_FILE_PATH
 from setup_wizard.tests.logger import Logger
 from setup_wizard.tests.models.test_operator_executioner import GenshinImpactTestOperatorExecutioner
 
@@ -71,12 +72,12 @@ def setup_character(config, character_name, character_folder_file_path, arg_mate
             GenshinImpactTestOperatorExecutioner('import_character_model', file_directory=character_folder_file_path),
             GenshinImpactTestOperatorExecutioner('delete_empties'),
             GenshinImpactTestOperatorExecutioner('import_materials', 
-                file_directory=config.get(FESTIVITY_ROOT_FOLDER_FILE_PATH) or '',
-                filepath=config.get(FESTIVITY_SHADER_FILE_PATH) or '',
+                file_directory=config.get(GENSHIN_IMPACT_ROOT_FOLDER_FILE_PATH) or '',
+                filepath=config.get(GENSHIN_IMPACT_SHADER_FILE_PATH) or '',
             ),
             GenshinImpactTestOperatorExecutioner('replace_default_materials'),
             GenshinImpactTestOperatorExecutioner('import_character_textures'),
-            GenshinImpactTestOperatorExecutioner('import_outlines', filepath=config.get(FESTIVITY_OUTLINES_FILE_PATH)),
+            GenshinImpactTestOperatorExecutioner('import_outlines', filepath=config.get(GENSHIN_IMPACT_OUTLINES_FILE_PATH)),
             GenshinImpactTestOperatorExecutioner('setup_geometry_nodes'),
             GenshinImpactTestOperatorExecutioner('import_outline_lightmaps', file_directory=character_folder_file_path),
             GenshinImpactTestOperatorExecutioner('import_material_data', 

--- a/setup_wizard/tests/test_honkai_star_rail_character_setup.py
+++ b/setup_wizard/tests/test_honkai_star_rail_character_setup.py
@@ -4,8 +4,8 @@ import logging
 import os
 import sys
 from pathlib import PurePath
-from setup_wizard.tests.constants import FESTIVITY_ROOT_FOLDER_FILE_PATH, \
-    FESTIVITY_SHADER_FILE_PATH, FESTIVITY_OUTLINES_FILE_PATH
+from setup_wizard.import_order import HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH, HONKAI_STAR_RAIL_SHADER_FILE_PATH, \
+    HONKAI_STAR_RAIL_OUTLINES_FILE_PATH
 from setup_wizard.tests.logger import Logger
 from setup_wizard.tests.models.test_operator_executioner import HonkaiStarRailTestOperatorExecutioner
 
@@ -67,12 +67,12 @@ def setup_character(config, character_name, character_folder_file_path, arg_mate
             HonkaiStarRailTestOperatorExecutioner('import_character_model', file_directory=character_folder_file_path),
             HonkaiStarRailTestOperatorExecutioner('delete_empties'),
             HonkaiStarRailTestOperatorExecutioner('import_materials', 
-                file_directory=config.get(FESTIVITY_ROOT_FOLDER_FILE_PATH) or '',
-                filepath=config.get(FESTIVITY_SHADER_FILE_PATH) or '',
+                file_directory=config.get(HONKAI_STAR_RAIL_ROOT_FOLDER_FILE_PATH) or '',
+                filepath=config.get(HONKAI_STAR_RAIL_SHADER_FILE_PATH) or '',
             ),
             HonkaiStarRailTestOperatorExecutioner('replace_default_materials'),
             HonkaiStarRailTestOperatorExecutioner('import_character_textures'),
-            HonkaiStarRailTestOperatorExecutioner('import_outlines', filepath=config.get(FESTIVITY_OUTLINES_FILE_PATH)),
+            HonkaiStarRailTestOperatorExecutioner('import_outlines', filepath=config.get(HONKAI_STAR_RAIL_OUTLINES_FILE_PATH)),
             HonkaiStarRailTestOperatorExecutioner('setup_geometry_nodes'),
             HonkaiStarRailTestOperatorExecutioner('import_outline_lightmaps', file_directory=character_folder_file_path),
             HonkaiStarRailTestOperatorExecutioner('import_material_data', 

--- a/setup_wizard/tests/test_punishing_gray_raven_character_setup.py
+++ b/setup_wizard/tests/test_punishing_gray_raven_character_setup.py
@@ -4,9 +4,9 @@ import logging
 import os
 import sys
 from pathlib import PurePath
-from setup_wizard.import_order import JAREDNYTS_PGR_CHIBI_MESH_FILE_PATH
-from setup_wizard.tests.constants import FESTIVITY_ROOT_FOLDER_FILE_PATH, \
-    FESTIVITY_SHADER_FILE_PATH, FESTIVITY_OUTLINES_FILE_PATH, GENSHIN_RIGIFY_BONE_SHAPES_FILE_PATH, RIG_CHARACTER
+from setup_wizard.import_order import PUNISHING_GRAY_RAVEN_ROOT_FOLDER_FILE_PATH, PUNISHING_GRAY_RAVEN_SHADER_FILE_PATH, \
+    PUNISHING_GRAY_RAVEN_OUTLINES_FILE_PATH, PUNISHING_GRAY_RAVEN_CHIBI_MESH_FILE_PATH
+from setup_wizard.tests.constants import RIG_CHARACTER
 from setup_wizard.tests.logger import Logger
 from setup_wizard.tests.models.test_operator_executioner import PunishingGrayRavenTestOperatorExecutioner
 
@@ -72,12 +72,12 @@ def setup_character(config, character_name, character_folder_file_path, arg_mate
             PunishingGrayRavenTestOperatorExecutioner('import_character_model', file_directory=character_folder_file_path),
             PunishingGrayRavenTestOperatorExecutioner('delete_empties'),
             PunishingGrayRavenTestOperatorExecutioner('import_materials', 
-                file_directory=config.get(FESTIVITY_ROOT_FOLDER_FILE_PATH) or '',
-                filepath=config.get(FESTIVITY_SHADER_FILE_PATH) or '',
+                file_directory=config.get(PUNISHING_GRAY_RAVEN_ROOT_FOLDER_FILE_PATH) or '',
+                filepath=config.get(PUNISHING_GRAY_RAVEN_SHADER_FILE_PATH) or '',
             ),
             PunishingGrayRavenTestOperatorExecutioner('replace_default_materials'),
             PunishingGrayRavenTestOperatorExecutioner('import_character_textures'),
-            PunishingGrayRavenTestOperatorExecutioner('import_outlines', filepath=config.get(FESTIVITY_OUTLINES_FILE_PATH)),
+            PunishingGrayRavenTestOperatorExecutioner('import_outlines', filepath=config.get(PUNISHING_GRAY_RAVEN_OUTLINES_FILE_PATH)),
             PunishingGrayRavenTestOperatorExecutioner('setup_geometry_nodes'),
             PunishingGrayRavenTestOperatorExecutioner('import_outline_lightmaps', file_directory=character_folder_file_path),
             # PunishingGrayRavenTestOperatorExecutioner('import_material_data', 
@@ -91,7 +91,7 @@ def setup_character(config, character_name, character_folder_file_path, arg_mate
             PunishingGrayRavenTestOperatorExecutioner('delete_specific_objects'),
             PunishingGrayRavenTestOperatorExecutioner('set_up_armtwist_bone_constraints'),
             PunishingGrayRavenTestOperatorExecutioner('join_meshes_on_armature'),
-            PunishingGrayRavenTestOperatorExecutioner('rootshape_filepath_setter', filepath=config.get(GENSHIN_RIGIFY_BONE_SHAPES_FILE_PATH)),
+            # PunishingGrayRavenTestOperatorExecutioner('rootshape_filepath_setter', filepath=config.get(GENSHIN_RIGIFY_BONE_SHAPES_FILE_PATH)),
             PunishingGrayRavenTestOperatorExecutioner('rig_character', config=config),
             PunishingGrayRavenTestOperatorExecutioner('paint_vertex_colors'),
         ]
@@ -107,7 +107,7 @@ def setup_character(config, character_name, character_folder_file_path, arg_mate
             operator.execute()
 
         chibi_operators = [
-            PunishingGrayRavenTestOperatorExecutioner('set_up_chibi_face_mesh', filepath=config.get(JAREDNYTS_PGR_CHIBI_MESH_FILE_PATH)),
+            PunishingGrayRavenTestOperatorExecutioner('set_up_chibi_face_mesh', filepath=config.get(PUNISHING_GRAY_RAVEN_CHIBI_MESH_FILE_PATH)),
             PunishingGrayRavenTestOperatorExecutioner('import_chibi_face_texture', file_directory=character_folder_file_path),
         ]
         if [material for material in bpy.data.materials if 'XDefaultMaterial' in material.name]:


### PR DESCRIPTION
## ⭐ QoL Feature
1. Filepaths to shaders/outlines are saved across addon versions now!
    a. They are saved to Blender's config folder
    b. No more need to re-select the shader or outlines file after installing a new addon version