### PR TITLE
refactor: auto-dependency setup works for Blender 3.6 and 4.0

### DIFF
--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -13,7 +13,7 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
+  build_standalone:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -27,7 +27,7 @@ jobs:
         with:
           name: "Character_Setup_Wizard_Addon_${{github.ref_name}}"
           path: dist/setup_wizard/
-  build:
+  build_regular:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Upload Standalone Setup Wizard Package
         uses: actions/upload-artifact@v3
         with:
-          name: "Character_Setup_Wizard_Addon_${{github.ref_name}}"
+          name: "Character_Setup_Wizard_Addon_${{github.ref_name}}_Standalone"
           path: dist/setup_wizard/
   build_regular:
     runs-on: ubuntu-latest

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -17,9 +17,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Set Up Standalone Addon Folder Structure
+        run: |
+          rm -r setup_wizard/tests
+          mkdir -p dist/setup_wizard/setup_wizard
+          mv setup_wizard dist/setup_wizard
+      - name: Upload Standalone Setup Wizard Package
+        uses: actions/upload-artifact@v3
+        with:
+          name: "Character_Setup_Wizard_Addon_${{github.ref_name}}"
+          path: dist/setup_wizard/
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
       - name: Set Up Addon Folder Structure
         run: |
           rm -r setup_wizard/tests
+          rm -r setup_wizard/dependencies
           mkdir -p dist/setup_wizard/setup_wizard
           mv setup_wizard dist/setup_wizard
       - name: Upload Setup Wizard Package

--- a/.github/workflows/package.yaml
+++ b/.github/workflows/package.yaml
@@ -2,15 +2,28 @@ name: Package Addons
 
 on:
   push:
-    branches:
-      - 'main'
     tags:
-      - '*'
+      - "v*"
     paths-ignore:
       - '**/.tmp'
       - '**/.gitignore'
       - '**/.gitattributes'
   workflow_dispatch:
+
+permissions:
+  actions: write
+  checks: read
+  contents: write
+  packages: write
+  deployments: write
+  id-token: write
+  issues: read
+  discussions: read
+  pages: read
+  pull-requests: read
+  repository-projects: read
+  security-events: read
+  statuses: read
 
 jobs:
   build_standalone:
@@ -23,7 +36,7 @@ jobs:
           mkdir -p dist/setup_wizard/setup_wizard
           mv setup_wizard dist/setup_wizard
       - name: Upload Standalone Setup Wizard Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Character_Setup_Wizard_Addon_${{github.ref_name}}_Standalone"
           path: dist/setup_wizard/
@@ -38,7 +51,33 @@ jobs:
           mkdir -p dist/setup_wizard/setup_wizard
           mv setup_wizard dist/setup_wizard
       - name: Upload Setup Wizard Package
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "Character_Setup_Wizard_Addon_${{github.ref_name}}"
           path: dist/setup_wizard/
+  tagged-release:
+    name: Tagged Release
+    needs: [build_standalone, build_regular]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        name: Character_Setup_Wizard_Addon_${{github.ref_name}}_Standalone
+      - uses: actions/download-artifact@v4
+        name: Character_Setup_Wizard_Addon_${{github.ref_name}}
+      - name: Display structure of downloaded files
+        run: ls -R
+      - name: Zip folders
+        run: |
+            cd Character_Setup_Wizard_Addon_${{github.ref_name}}_Standalone
+            zip -r Character_Setup_Wizard_Addon_${{github.ref_name}}_Standalone.zip setup_wizard -x ".git*"
+            cd ../Character_Setup_Wizard_Addon_${{github.ref_name}}
+            zip -r Character_Setup_Wizard_Addon_${{github.ref_name}}.zip setup_wizard -x ".git*"
+            ls -R
+      - uses: "marvinpinto/action-automatic-releases@v1.2.1"
+        with:
+          repo_token: "${{ secrets.GITHUB_TOKEN }}"
+          prerelease: true
+          title: "Test"
+          files: |
+            Character_Setup_Wizard_Addon_${{github.ref_name}}_Standalone/Character_Setup_Wizard_Addon_${{github.ref_name}}_Standalone.zip
+            Character_Setup_Wizard_Addon_${{github.ref_name}}/Character_Setup_Wizard_Addon_${{github.ref_name}}.zip

--- a/setup_wizard/__init__.py
+++ b/setup_wizard/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "HoYoverse Setup Wizard",
     "author": "Mken, OctavoPE, Enthralpy",
-    "version": (2, 4, 3),
+    "version": (2, 4, 4),
     "blender": (3, 3, 0),
     "location": "3D View > Sidebar > Genshin Impact / Honkai Star Rail / Punishing Gray Raven",
     "description": "An addon to streamline the character model setup process when using Festivity, Nya222's or JaredNyts' Shaders",

--- a/setup_wizard/genshin_setup_wizard.py
+++ b/setup_wizard/genshin_setup_wizard.py
@@ -106,13 +106,27 @@ def on_register():
         addons_to_enable = {'rigify': '', 'better_fbx': 'b_f-5.4.8.zip', 'Expy-Kit-main': 'Expy-Kit-v052.zip'}
         for addon, filename in addons_to_enable.items():
             try:
-                bpy.ops.preferences.addon_enable(module=addon)
-            except Exception as err:
-                addon_path = os.path.join(os.path.dirname(__file__), 'dependencies', filename)
-                print(f'Installing addon: {addon_path}')
-                bpy.ops.preferences.addon_install(filepath=addon_path, overwrite=False)
+                print(f'Enabling addon: {addon}')
+                status = bpy.ops.preferences.addon_enable(module=addon)
+                if status == {'FINISHED'}:
+                    print(f'Enabled addon: {addon}')
+                    continue
+                install_addon(addon, filename)
+            except Exception as err:  # Blender 3.6
+                install_addon(addon, filename)
     except Exception as err:
         print(f'Unexpected error when trying to enable/install addons: {err}')
+
+
+def install_addon(addon, filename):
+    addon_path = os.path.join(os.path.dirname(__file__), 'dependencies', filename)
+    if os.path.exists(addon_path):
+        print(f'Installing addon: {addon_path}')
+        bpy.ops.preferences.addon_install(filepath=addon_path, overwrite=False)
+        bpy.ops.preferences.addon_enable(module=addon)
+        print(f'Enabled addon: {addon}')
+    else:  #  is not standalone version of Setup Wizard
+        print(f'Addon file does not exist at {addon_path}. Unable to install {addon}.')
 
 
 # Legacy import system before this became an Addon. Refactoring necessary.


### PR DESCRIPTION
## Refactoring
1. Ensures auto-dependency setup works for Blender 3.6 and 4.0

## Github Action Workflows
1. Auto-create release with artifacts