### PR TITLE
revert: "Added visibility drivers to ColorPicker objects stashed in the Rig object"

### DIFF
--- a/setup_wizard/character_rig_setup/npc_rig_script.py
+++ b/setup_wizard/character_rig_setup/npc_rig_script.py
@@ -2318,15 +2318,7 @@ def rig_character(
             var.targets[0].id_type = "ARMATURE"
             var.targets[0].id = armature
             var.targets[0].data_path = path
-        
-        drive_visibility_with_prop("ColorPicker-Ambient","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-Fresnel","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-Lit","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-RimLit","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-RimShadow","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-Shadow","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-SoftLit","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-SoftShadow","collections[\"Lighting\"].is_visible")    
+            
         drive_visibility_with_prop("ColorWheel-Ambient","collections[\"Lighting\"].is_visible")
         drive_visibility_with_prop("ColorWheel-Fresnel","collections[\"Lighting\"].is_visible")
         drive_visibility_with_prop("ColorWheel-Lit","collections[\"Lighting\"].is_visible")

--- a/setup_wizard/character_rig_setup/rig_script.py
+++ b/setup_wizard/character_rig_setup/rig_script.py
@@ -2794,15 +2794,7 @@ def rig_character(
             var.targets[0].id_type = "ARMATURE"
             var.targets[0].id = armature
             var.targets[0].data_path = path
-
-        drive_visibility_with_prop("ColorPicker-Ambient","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-Fresnel","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-Lit","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-RimLit","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-RimShadow","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-Shadow","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-SoftLit","collections[\"Lighting\"].is_visible")
-        drive_visibility_with_prop("ColorPicker-SoftShadow","collections[\"Lighting\"].is_visible")
+            
         drive_visibility_with_prop("ColorWheel-Ambient","collections[\"Lighting\"].is_visible")
         drive_visibility_with_prop("ColorWheel-Fresnel","collections[\"Lighting\"].is_visible")
         drive_visibility_with_prop("ColorWheel-Lit","collections[\"Lighting\"].is_visible")


### PR DESCRIPTION
Reverts michael-gh1/Addons-And-Tools-For-Blender-miHoYo-Shaders#116

We realized these were from empties we don't actually want in the character rig. Keep them in `wgt` collection