### PR TITLE
fix: EyeStar is black after rigging; requires Light Vector setup

### DIFF
--- a/setup_wizard/__init__.py
+++ b/setup_wizard/__init__.py
@@ -1,7 +1,7 @@
 bl_info = {
     "name": "HoYoverse Setup Wizard",
     "author": "Mken, OctavoPE, Enthralpy",
-    "version": (2, 6, 2),
+    "version": (2, 6, 3),
     "blender": (3, 3, 0),
     "location": "3D View > Sidebar > Genshin Impact / Honkai Star Rail / Punishing Gray Raven",
     "description": "An addon to streamline the character model setup process when using Festivity, Nya222's or JaredNyts' Shaders",

--- a/setup_wizard/geometry_nodes_setup/geometry_nodes_setups.py
+++ b/setup_wizard/geometry_nodes_setup/geometry_nodes_setups.py
@@ -83,7 +83,8 @@ meshes_to_create_outlines_on = \
     pgr_meshes_to_create_outlines_on
 
 meshes_to_create_light_vectors_on = meshes_to_create_outlines_on + [
-    'Brow'
+    'Brow',
+    'EyeStar',
 ]
 
 class GameGeometryNodesSetupFactory:


### PR DESCRIPTION
1. Fixes `EyeStar` being black after rigging setup