### PR TITLE
fix: vanilla Blender setup and Columbina setup

### DIFF
--- a/setup_wizard/__init__.py
+++ b/setup_wizard/__init__.py
@@ -3,7 +3,7 @@ import os
 bl_info = {
     "name": "HoYoverse Setup Wizard",
     "author": "Mken, OctavoPE, Enthralpy",
-    "version": (2, 7, 2),
+    "version": (2, 7, 3),
     "blender": (3, 3, 0),
     "location": "3D View > Sidebar > Genshin Impact / Honkai Star Rail / Punishing Gray Raven",
     "description": "An addon to streamline the character model setup process when using Festivity, Nya222's or JaredNyts' Shaders",

--- a/setup_wizard/geometry_nodes_setup/geometry_nodes_setups.py
+++ b/setup_wizard/geometry_nodes_setup/geometry_nodes_setups.py
@@ -93,6 +93,7 @@ gi_meshes_to_create_outlines_on = [
     'Handcuffs',
     'Hat',
     'Helmet',
+    'Headwear',
     'SkillObj_Mavuika_Glass_Model',
     'Skirt',
     'Wriothesley_Gauntlet_L_Model',

--- a/setup_wizard/geometry_nodes_setup/geometry_nodes_setups.py
+++ b/setup_wizard/geometry_nodes_setup/geometry_nodes_setups.py
@@ -132,6 +132,7 @@ meshes_to_create_outlines_on = \
 meshes_to_create_light_vectors_on = meshes_to_create_outlines_on + [
     'Brow',
     'EyeStar',
+    'Pupil',
 ]
 
 material_keywords_to_not_create_outlines_on = [

--- a/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
+++ b/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
@@ -246,6 +246,11 @@ class GenshinImpactDefaultMaterialReplacer(GameDefaultMaterialReplacer):
         return material_name
 
     def add_light_group_to_material(self, material, character_name):
+        if not material or \
+                not hasattr(material, 'light_groups') or \
+                not hasattr(material.light_groups, 'groups'):
+            return None
+
         light_group = material.light_groups.groups.get(character_name)
 
         if not light_group:

--- a/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
+++ b/setup_wizard/replace_default_materials_setup/game_default_material_replacers.py
@@ -214,7 +214,8 @@ class GenshinImpactDefaultMaterialReplacer(GameDefaultMaterialReplacer):
             skillobj_material.name = skillobj_material.name.replace(ShaderMaterialNameKeywords.SKILLOBJ, mesh_body_part_name)
             material_name = skillobj_material.name
         elif mesh_body_part_name == 'Ribbon':
-            ribbon_material = self.create_vfx_material(self.material_names, f'{self.material_names.MATERIAL_PREFIX}Ribbon', VFXShaderTypes.RIBBON)
+            ribbon_material = self.create_vfx_material(self.material_names, self.material_names.RIBBON, VFXShaderTypes.RIBBON) or \
+                self.create_body_material(self.material_names, f'{self.material_names.MATERIAL_PREFIX}Ribbon')
             if ribbon_material:
                 material_name = ribbon_material.name
         elif mesh_body_part_name == 'Skirt':

--- a/setup_wizard/texture_import_setup/texture_importer_types.py
+++ b/setup_wizard/texture_import_setup/texture_importer_types.py
@@ -163,16 +163,17 @@ class GenshinTextureImporter:
                         type(self) is GenshinNPCTextureImporter:
                         self.setup_dress_textures(texture_node_name, img, self.character_type)
 
-    def set_lightmap_texture(self, texture_type: TextureType, material, img):
+    def set_lightmap_texture(self, texture_type: TextureType, material, img, texture_node_names: List[str]=[], override=True):
         img.colorspace_settings.name='Non-Color'
-        possible_texture_node_names = [
+        possible_texture_node_names = texture_node_names if texture_node_names else [
             f'{texture_type.value}_Lightmap_UV0',
             f'{texture_type.value}_Lightmap_UV1',
             V1_HoYoToonGenshinImpactTextureNodeNames.LIGHTMAP,
         ]
         for texture_node_name in possible_texture_node_names:
             if material.node_tree.nodes.get(texture_node_name):
-                material.node_tree.nodes[texture_node_name].image = img
+                if override or not material.node_tree.nodes[texture_node_name].image:
+                    material.node_tree.nodes[texture_node_name].image = img
         
                 if self.game_type == GameType.GENSHIN_IMPACT:
                     if not self.does_dress_texture_exist_in_directory_files() or \
@@ -522,7 +523,7 @@ class GenshinAvatarTextureImporter(GenshinTextureImporter):
                 glass_eff_material = bpy.data.materials.get(f'{self.material_names.GLASS_EFF}')
                 leather_material = bpy.data.materials.get(f'{self.material_names.LEATHER}')
                 pupil_material = bpy.data.materials.get(f'{self.material_names.PUPIL}')
-                ribbon_material = bpy.data.materials.get(f'{self.material_names.RIBBON}')
+                ribbon_material = bpy.data.materials.get(f'{self.material_names.RIBBON}') or bpy.data.materials.get(f'{self.material_names.MATERIAL_PREFIX}Ribbon')  # for older shader version "support"
                 skirt_material = bpy.data.materials.get(f'{self.material_names.SKIRT}')
                 star_cloak_material = bpy.data.materials.get(f'{self.material_names.STAR_CLOAK}')
                 stockings_material = bpy.data.materials.get(f'{self.material_names.STOCKINGS}')
@@ -571,7 +572,11 @@ class GenshinAvatarTextureImporter(GenshinTextureImporter):
                     self.set_body_hair_output_on_face_shader(face_material, img)
                     self.set_diffuse_texture(TextureType.BODY, leather_material, img) if leather_material else None
                     self.set_diffuse_texture(TextureType.BODY, pupil_material, img) if pupil_material else None
-                    self.set_diffuse_texture(TextureType.BODY, ribbon_material, img, texture_node_names=[V1_HoYoToonGenshinImpactTextureNodeNames.VFX_DIFFUSE]) if ribbon_material else None
+                    self.set_diffuse_texture(TextureType.BODY, ribbon_material, img, texture_node_names=[
+                        V1_HoYoToonGenshinImpactTextureNodeNames.VFX_DIFFUSE, 
+                        V1_HoYoToonGenshinImpactTextureNodeNames.BODY_DIFFUSE_UV0, 
+                        V1_HoYoToonGenshinImpactTextureNodeNames.BODY_DIFFUSE_UV1
+                    ]) if ribbon_material else None
                     self.set_diffuse_texture(TextureType.BODY, glass_material, img, texture_node_names=[V1_HoYoToonGenshinImpactTextureNodeNames.VFX_DIFFUSE]) if glass_material else None
                     if star_cloak_material and self.star_cloak_uses_body_texture(file):
                         self.set_diffuse_texture(TextureType.BODY, star_cloak_material, img)
@@ -588,6 +593,10 @@ class GenshinAvatarTextureImporter(GenshinTextureImporter):
                     self.set_lightmap_texture(TextureType.BODY, selected_body_material, img)
                     self.set_lightmap_texture(TextureType.BODY, leather_material, img) if leather_material else None
                     self.set_lightmap_texture(TextureType.BODY, pupil_material, img) if pupil_material else None
+                    self.set_lightmap_texture(TextureType.BODY, ribbon_material, img, texture_node_names=[
+                        V1_HoYoToonGenshinImpactTextureNodeNames.BODY_LIGHTMAP_UV0, 
+                        V1_HoYoToonGenshinImpactTextureNodeNames.BODY_LIGHTMAP_UV1
+                    ]) if ribbon_material else None  # ONLY FOR OLDER VERSION SUPPORT, was told Columbina's Ribbon is not supposed to have Lightmap set up - b86c72dce5b754bf3ea4953582c962c6b77ccc53
                 elif self.is_texture_identifiers_in_texture_name([ShaderMaterialNameKeywords.BODY, ShaderMaterialNameKeywords.NORMAL_MAP], file):
                     self.set_normalmap_texture(TextureType.BODY, body_material, img)
                     self.set_normalmap_texture(TextureType.BODY, leather_material, img) if leather_material else None

--- a/setup_wizard/texture_import_setup/texture_node_names.py
+++ b/setup_wizard/texture_import_setup/texture_node_names.py
@@ -4,6 +4,9 @@
 class TextureNodeNames:
     DIFFUSE = ''
     BODY_DIFFUSE_UV0 = ''
+    BODY_DIFFUSE_UV1 = ''
+    BODY_LIGHTMAP_UV0 = ''
+    BODY_LIGHTMAP_UV1 = ''
     MAIN_DIFFUSE = ''
     LIGHTMAP = ''
     SHADER_TEXTURES_NODE_GROUP = ''
@@ -55,6 +58,9 @@ class TextureNodeNames:
 
 class GenshinImpactTextureNodeNames(TextureNodeNames):
     BODY_DIFFUSE_UV0 = 'Body_Diffuse_UV0'  # For getting body shader name when renaming shader material names
+    BODY_DIFFUSE_UV1 = 'Body_Diffuse_UV1'
+    BODY_LIGHTMAP_UV0 = 'Body_Lightmap_UV0'
+    BODY_LIGHTMAP_UV1 = 'Body_Lightmap_UV1'
 
 class V1_GenshinImpactTextureNodeNames(GenshinImpactTextureNodeNames):
     LIGHTMAP = 'Image Texture'


### PR DESCRIPTION
1. Fix erroring on accessing Light Group in Vanilla Blender
2. Fix Columbina Pupil not getting Light Vectors created
3. Fix Columbina Headwear not getting outlines created
4. Fix Columbina setup for current public shader (v3.4)