### PR TITLE
feat: support newer versions of BetterFBX (6.3.3)

### DIFF
--- a/setup_wizard/genshin_import_character_model.py
+++ b/setup_wizard/genshin_import_character_model.py
@@ -139,11 +139,16 @@ class GI_OT_GenshinImportModel(Operator, ImportHelper, CustomOperatorProperties)
             bpy.context.window_manager.setup_wizard_betterfbx_enabled if betterfbx_installed else False
 
         if betterfbx_installed and betterfbx_enabled:
-            bpy.ops.better_import.fbx(
-                'EXEC_DEFAULT',
-                filepath=character_model_file_path,
-                use_auto_bone_orientation=self.use_auto_bone_orientation,
-            )
+            betterfbx_kwargs = {
+                'filepath': character_model_file_path,
+                'files': [{'name': os.path.basename(character_model_file_path)}],  # needed after upgrading BetterFBX to 6.3
+                'use_auto_bone_orientation': self.use_auto_bone_orientation,
+            }
+            # use_single_armature only exists in at least BetterFBX >= 6.3.3 (unsure when it was exactly introduced)
+            # keep imported model in the same format as when using BetterFBX 5.4.8
+            if bpy.ops.better_import.fbx.get_rna_type().properties.get('use_single_armature'):
+                betterfbx_kwargs['use_single_armature'] = False
+            bpy.ops.better_import.fbx('EXEC_DEFAULT', **betterfbx_kwargs)
             self.report({'INFO'}, 'Imported character model using BetterFBX')
         else:
             bpy.ops.import_scene.fbx(

--- a/setup_wizard/genshin_setup_wizard.py
+++ b/setup_wizard/genshin_setup_wizard.py
@@ -103,7 +103,7 @@ def register():
 def on_register():
     try:
         # Enable Rigify, BetterFBX and ExpyKit. If they don't exist, install them from dependencies folder
-        addons_to_enable = {'rigify': '', 'better_fbx': 'b_f-5.4.8.zip', 'Expy-Kit-main': 'Expy-Kit-v052.zip'}
+        addons_to_enable = {'rigify': '', 'better_fbx': 'b_f-6.3.3.zip', 'Expy-Kit-main': 'Expy-Kit-v052.zip'}
         for addon, filename in addons_to_enable.items():
             try:
                 print(f'Enabling addon: {addon}')


### PR DESCRIPTION
- fix required `files` parameter that needs to be passed in
- keep the same imported model hierarchy by using `use_single_armature`
  - swapped from defaulting to `False` to `True` in newer versions



Copilot Notes
> BetterFBX 6.3.3 removed the else branch in its execute() method that previously handled programmatic calls using only filepath. Without files populated, the operator falls through without returning {'FINISHED'}, causing a RuntimeError: incompatible return value. Passing files=[{'name': os.path.basename(filepath)}] forces 6.3.3 into its if self.files: branch while remaining fully backwards-compatible with BetterFBX 5.4.8, which handles both branches identically.