### PR TITLE
fix: Rigging warning for some NPC models

### DIFF
--- a/setup_wizard/character_rig_setup/hsr_rig_script.py
+++ b/setup_wizard/character_rig_setup/hsr_rig_script.py
@@ -512,9 +512,10 @@ def rig_character(
     except:
         pass
     x = original_name.split("_")
-    bpy.data.objects["rigify"].users_collection[0].name = x[-2]
-    bpy.data.objects["rigify"].name = x[-2] + "Rig"
-
+    if len(x) > 1:
+        bpy.data.objects["rigify"].users_collection[0].name = x[-2]
+        bpy.data.objects["rigify"].name = x[-2] + "Rig"
+    
 try:
     bpy.context.scene.objects["Head Forward"].hide_viewport = True
     bpy.context.scene.objects["Head Up"].hide_viewport = True


### PR DESCRIPTION
Making rig via `Rig Character (Preview)` when the armature doesn't provide the usual model's name (for example: "Art_Aventurine_00") will cause `list index out of range` error.

This error example is derived from an NPC model that doesn't have the `Art_xxx_00` name template, it will be named as `Armature` instead.
Since when we `split()` the `Armature` object name and it length is only 1, accessing it with index `-2` will throw an error.

This fix is to suppress the warning, `rename` lines will only run when the object name that has been split has a length greater than 1 (for example, "Art_Aventurine_00" has length of 3 when splitted, hence `-2` index work)

<img width="341" height="74" alt="image" src="https://github.com/user-attachments/assets/a7ab3953-0381-49de-a791-400607814cdf" />
